### PR TITLE
Fix VariableType::ID() error in demo_graph when constants are involved

### DIFF
--- a/demo_graph.py
+++ b/demo_graph.py
@@ -83,7 +83,7 @@ class SimpleModel(nn.Module):
     def __init__(self):
         super(SimpleModel, self).__init__()
     def forward(self, x):
-        return x*2
+        return x*torch.FloatTensor([2])
         
 
 model = SimpleModel()


### PR DESCRIPTION
Wrapping constant in torch.FloatTensor fixes the following error (pytorch==0.4.0, tensorboardX==1.2)

/home/dineshj/anaconda/envs/py35/lib/python3.5/site-packages/torchvision-0.2.1-py3.5.egg/torchvision/models/densenet.py:212: UserWarning: nn.init.kaiming_normal is now deprecated in favor of nn.init.kaiming_norm
al_.
Traceback (most recent call last):
  File "demo_graph.py", line 94, in <module>
    w.add_graph(model, dummy_input)
  File "/home/dineshj/anaconda/envs/py35/lib/python3.5/site-packages/tensorboardX/writer.py", line 419, in add_graph
    self.file_writer.add_graph(graph(model, input_to_model, verbose))
  File "/home/dineshj/anaconda/envs/py35/lib/python3.5/site-packages/tensorboardX/graph.py", line 85, in graph
    list_of_nodes = parse(graph)
  File "/home/dineshj/anaconda/envs/py35/lib/python3.5/site-packages/tensorboardX/graph.py", line 28, in parse
    attrs = {k: n[k] for k in n.attributeNames()}
  File "/home/dineshj/anaconda/envs/py35/lib/python3.5/site-packages/tensorboardX/graph.py", line 28, in <dictcomp>
    attrs = {k: n[k] for k in n.attributeNames()}
  File "/home/dineshj/anaconda/envs/py35/lib/python3.5/site-packages/torch/onnx/utils.py", line 444, in _node_getitem
    return getattr(self, sel)(k)
RuntimeError: VariableType::ID() not implemented