### PR TITLE
Prevent using extra memory for `make_mat`

### DIFF
--- a/tensorboardX/embedding.py
+++ b/tensorboardX/embedding.py
@@ -52,5 +52,5 @@ def append_pbtxt(metadata, label_img, save_path, subdir, global_step, tag):
 def make_mat(matlist, save_path):
     with open(os.path.join(save_path, 'tensors.tsv'), 'w') as f:
         for x in matlist:
-            x = [str(i) for i in x]
+            x = [str(i.item()) for i in x]
             f.write('\t'.join(x) + '\n')

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -590,7 +590,7 @@ class SummaryWriter(object):
             assert mat.size(0) == label_img.size(0), '#images should equal with #data points'
             make_sprite(label_img, save_path)
         assert mat.dim() == 2, 'mat should be 2D, where mat.size(0) is the number of data points'
-        make_mat(mat.tolist(), save_path)
+        make_mat(mat, save_path)
         # new funcion to append to the config file a new embedding
         append_pbtxt(metadata, label_img, self.file_writer.get_logdir(), subdir, global_step, tag)
 


### PR DESCRIPTION
`mat.tolist()` allocates extra memory. This may be a problem for very large embeddings.

Compatible with `pytorch>=0.4`.