### PR TITLE
Add support for logging directly to S3

### DIFF
--- a/tensorboardX/event_file_writer.py
+++ b/tensorboardX/event_file_writer.py
@@ -27,14 +27,7 @@ import time
 import six
 
 from .proto import event_pb2
-from .record_writer import RecordWriter
-
-
-def directory_check(path):
-    '''Initialize the directory for log files.'''
-    # If the direcotry does not exist, create it!
-    if not os.path.exists(path):
-        os.makedirs(path)
+from .record_writer import RecordWriter, directory_check
 
 
 class EventsWriter(object):

--- a/tensorboardX/record_writer.py
+++ b/tensorboardX/record_writer.py
@@ -3,13 +3,101 @@ To write tf_record into file. Here we use it for tensorboard's event writting.
 The code was borrow from https://github.com/TeamHG-Memex/tensorboard_logger
 """
 
+import io
+import os.path
 import re
 import struct
+try:
+    import boto3
+    S3_ENABLED = True
+except ImportError:
+    S3_ENABLED = False
 
 from .crc32c import crc32c
 
+
 _VALID_OP_NAME_START = re.compile('^[A-Za-z0-9.]')
 _VALID_OP_NAME_PART = re.compile('[A-Za-z0-9_.\\-/]+')
+
+# Registry of writer factories by prefix backends.
+#
+# Currently supports "s3://" URLs for S3 based on boto and falls
+# back to local filesystem.
+REGISTERED_FACTORIES = {}
+
+
+def register_writer_factory(prefix, factory):
+    if ':' in prefix:
+        raise ValueError('prefix cannot contain a :')
+    REGISTERED_FACTORIES[prefix] = factory
+
+
+def directory_check(path):
+    '''Initialize the directory for log files.'''
+    try:
+        prefix = path.split(':')[0]
+        factory = REGISTERED_FACTORIES[prefix]
+        return factory.directory_check(path)
+    except KeyError:
+        if not os.path.exists(path):
+            os.makedirs(path)
+
+
+def open_file(path):
+    '''Open a writer for outputting event files.'''
+    try:
+        prefix = path.split(':')[0]
+        factory = REGISTERED_FACTORIES[prefix]
+        return factory.open(path, 'wb')
+    except KeyError:
+        return open(path, 'wb')
+
+
+class S3RecordWriter(object):
+    """Writes tensorboard protocol buffer files to S3."""
+
+    def __init__(self, path, mode):
+        if not S3_ENABLED:
+            raise ImportError("boto3 must be installed for S3 support.")
+        if mode != "wb" and mode != "bw":
+            raise ValueError("mode {} is not supported.".format(mode))
+        self.path = path
+        self.buffer = io.BytesIO()
+
+    def __del__(self):
+        self.close()
+
+    def bucket_and_path(self):
+        bp = self.path.split("/")
+        bucket = bp[0]
+        path = self.path[1 + len(bucket):]
+        return bucket, path
+
+    def write(self, val):
+        self.buffer.write(val)
+
+    def flush(self):
+        s3 = boto3.client('s3')
+        bucket, path = self.bucket_and_path()
+        s3.upload_fileobj(self.buffer, bucket, path)
+
+    def close(self):
+        self.flush()
+
+
+class S3RecordWriterFactory(object):
+    """Factory for event protocol buffer files to S3."""
+
+    def open(self, path, mode="wb"):
+        return S3RecordWriter(path, mode)
+
+    def directory_check(self, path):
+        # S3 doesn't need directories created before files are added
+        # so we can just skip this check
+        pass
+
+
+register_writer_factory("s3", S3RecordWriterFactory())
 
 
 class RecordWriter(object):
@@ -20,7 +108,7 @@ class RecordWriter(object):
         # TODO. flush every flush_secs, not every time.
         self.flush_secs = flush_secs
         self._writer = None
-        self._writer = open(path, 'wb')
+        self._writer = open_file(path)
 
     def write(self, event_str):
         w = self._writer.write

--- a/tensorboardX/record_writer.py
+++ b/tensorboardX/record_writer.py
@@ -1,6 +1,6 @@
 """
 To write tf_record into file. Here we use it for tensorboard's event writting.
-The code was borrow from https://github.com/TeamHG-Memex/tensorboard_logger
+The code was borrowed from https://github.com/TeamHG-Memex/tensorboard_logger
 """
 
 import io
@@ -48,7 +48,7 @@ def open_file(path):
     try:
         prefix = path.split(':')[0]
         factory = REGISTERED_FACTORIES[prefix]
-        return factory.open(path, 'wb')
+        return factory.open(path)
     except KeyError:
         return open(path, 'wb')
 
@@ -56,11 +56,9 @@ def open_file(path):
 class S3RecordWriter(object):
     """Writes tensorboard protocol buffer files to S3."""
 
-    def __init__(self, path, mode):
+    def __init__(self, path):
         if not S3_ENABLED:
             raise ImportError("boto3 must be installed for S3 support.")
-        if mode != "wb" and mode != "bw":
-            raise ValueError("mode {} is not supported.".format(mode))
         self.path = path
         self.buffer = io.BytesIO()
 
@@ -88,8 +86,8 @@ class S3RecordWriter(object):
 class S3RecordWriterFactory(object):
     """Factory for event protocol buffer files to S3."""
 
-    def open(self, path, mode="wb"):
-        return S3RecordWriter(path, mode)
+    def open(self, path):
+        return S3RecordWriter(path)
 
     def directory_check(self, path):
         # S3 doesn't need directories created before files are added

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -252,8 +252,8 @@ class SummaryWriter(object):
               this argument will no effect.
             purge_step (int):
               When logging crashes at step :math:`T+X` and restarts at step :math:`T`, any events
-              whose global_step larger or euqal to :math:`T` will be purged and hiding from TensorBoard.
-              Note that the resumed experiment and the crashed experiment should have the same ``log_dir``.
+              whose global_step larger or equal to :math:`T` will be purged and hidden from TensorBoard.
+              Note that the resumed experiment and crashed experiment should have the same ``log_dir``.
             filename_suffix (string):
               Every event file's name is suffixed with suffix. example: ``SummaryWriter(filename_suffix='.123')``
             kwargs: extra keyword arguments for FileWriter (e.g. 'flush_secs'
@@ -266,11 +266,10 @@ class SummaryWriter(object):
             current_time = datetime.now().strftime('%b%d_%H-%M-%S')
             log_dir = os.path.join(
                 'runs', current_time + '_' + socket.gethostname() + comment)
+        self.log_dir = log_dir
 
         if 'purge_step' in kwargs.keys():
             most_recent_step = kwargs.pop('purge_step')
-            if not os.path.exists(log_dir):
-                print('warning: you are purging unexisting data.')
             self.file_writer = FileWriter(logdir=log_dir, **kwargs)
             self.file_writer.add_event(
                 Event(step=most_recent_step, file_version='brain.Event:2'))


### PR DESCRIPTION
TensorBoard already supports reading from an S3 location with `s3://bucket/url`. This adds support for logging data from tensorboardX directly to S3 so it can be consumed by TensorBoard.

This also allows us to add other storage systems (Google Cloud Storage, etc.) in the future.

@lanpa what do you think of this? Thanks.