### PR TITLE
Terminate _EventLoggerThread on EventFileWriter.close()

### DIFF
--- a/tensorboardX/event_file_writer.py
+++ b/tensorboardX/event_file_writer.py
@@ -116,6 +116,7 @@ class EventFileWriter(object):
         self._closed = False
         self._worker = _EventLoggerThread(self._event_queue, self._ev_writer,
                                           flush_secs)
+        self.flush_secs = flush_secs
 
         self._worker.start()
 
@@ -130,6 +131,9 @@ class EventFileWriter(object):
         Does nothing if the EventFileWriter was not closed.
         """
         if self._closed:
+            self._worker = _EventLoggerThread(self._event_queue, self._ev_writer,
+                                              self.flush_secs)
+            self._worker.start()
             self._closed = False
 
     def add_event(self, event):
@@ -152,9 +156,11 @@ class EventFileWriter(object):
         """Flushes the event file to disk and close the file.
         Call this method when you do not need the summary writer anymore.
         """
-        self.flush()
-        self._ev_writer.close()
-        self._closed = True
+        if not self._closed:
+            self._event_queue.put(None)
+            self.flush()
+            self._ev_writer.close()
+            self._closed = True
 
 
 class _EventLoggerThread(threading.Thread):
@@ -181,6 +187,8 @@ class _EventLoggerThread(threading.Thread):
         while True:
             event = self._queue.get()
             try:
+                if event is None:
+                    break
                 self._ev_writer.write_event(event)
                 # Flush the event writer every so often.
                 now = time.time()


### PR DESCRIPTION
https://github.com/lanpa/tensorboardX/issues/108

When closing a `SummaryWriter` the `_EventLoggerThread` is never closed. This creates problems for code similar to:
```python
for i in range(iterations):
    loss = ...
    with SummaryWriter('path/to/logdir') as writer:
        writer.add_scalar('loss', loss, i)
```

This simple solution passes `None` to the queue feeding the thread with new events as a way to communicate that the thread should terminate.

I also added code for restarting the thread in `EventFileWriter.reopen()`, although it seems like this function should not work as `EventFileWriter._ev_writer` is not reopened in it.