### PR TITLE
Fix protoc issues.

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -3,19 +3,30 @@
 # Exit on error
 # set -e
 
+DESIRED_PROTO_VERSION="3.6.1"
+
+# call protoc direclty, if version is not the desired one, download the desired vesrion.
 
 
-PROTOC_BIN=`which protoc`
-if [ -z ${PROTOC_BIN} ]; then
+if [ -f "protoc/bin/protoc" ]; then
+  PROTOC_BIN="protoc/bin/protoc"
+else
+  PROTOC_BIN=`which protoc`
+fi
+
+echo "using" $PROTOC_BIN
+
+CURRENT_PROTOC_VER=`${PROTOC_BIN} --version`
+if [ -z ${PROTOC_BIN} ] || [[ "$CURRENT_PROTOC_VER" == "libprotoc 2."* ]]; then
   # Download and use the latest version of protoc.
   if [ "$(uname)" == "Darwin" ]; then
-    PROTOC_ZIP="protoc-3.6.1-osx-x86_64.zip"
+    PROTOC_ZIP="protoc-"$DESIRED_PROTO_VERSION"-osx-x86_64.zip"
   else
-    PROTOC_ZIP="protoc-3.6.1-linux-x86_64.zip"
+    PROTOC_ZIP="protoc-"$DESIRED_PROTO_VERSION"-linux-x86_64.zip"
   fi
   WGET_BIN=`which wget`
   if [[ ! -z ${WGET_BIN} ]]; then
-    ${WGET_BIN} https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/${PROTOC_ZIP}
+    ${WGET_BIN} https://github.com/protocolbuffers/protobuf/releases/download/v"$DESIRED_PROTO_VERSION"/${PROTOC_ZIP}
     rm -rf protoc
     python -c "import zipfile; zipfile.ZipFile('"${PROTOC_ZIP}"','r').extractall('protoc')"
     PROTOC_BIN=protoc/bin/protoc


### PR DESCRIPTION
The original script fails the compile process when the system already has protoc v2.* because the proto version we use is proto3. Additionally, during developing tensorboardX, `python setup.py` might be executed frequently, which leads to many unnecessary downloads of protoc.zip, This patch solves the problem.