### PR TITLE
Fix S3 record writer

### DIFF
--- a/tensorboardX/record_writer.py
+++ b/tensorboardX/record_writer.py
@@ -80,7 +80,9 @@ class S3RecordWriter(object):
     def flush(self):
         s3 = boto3.client('s3')
         bucket, path = self.bucket_and_path()
-        s3.upload_fileobj(self.buffer, bucket, path)
+        upload_buffer = copy.copy(self.buffer)
+        upload_buffer.seek(0)
+        s3.upload_fileobj(upload_buffer, bucket, path)
 
     def close(self):
         self.flush()

--- a/tensorboardX/record_writer.py
+++ b/tensorboardX/record_writer.py
@@ -3,6 +3,7 @@ To write tf_record into file. Here we use it for tensorboard's event writting.
 The code was borrowed from https://github.com/TeamHG-Memex/tensorboard_logger
 """
 
+import copy
 import io
 import os.path
 import re

--- a/tensorboardX/record_writer.py
+++ b/tensorboardX/record_writer.py
@@ -71,7 +71,7 @@ class S3RecordWriter(object):
             path = path[len("s3://"):]
         bp = path.split("/")
         bucket = bp[0]
-        path = self.path[1 + len(bucket):]
+        path = path[1 + len(bucket):]
         return bucket, path
 
     def write(self, val):


### PR DESCRIPTION
There was a bug in `S3RecordWriter` that caused a malformed path. This was because `self.path[1 + len(bucket):]` referenced the attribute `self.path` instead of the local `path` variable.

Example:
```
self.path = "s3://my-bucket/path"
path = self.path
if self.path.startswith("s3://"):
    path = self.path[len("s3://"):]
bp = path.split("/")
bucket = bp[0]
path = self.path[1 + len(bucket):]
return bucket, path
# output = ('my-bucket', 'cket/path')
```

Changed it to `path[1 + len(bucket):]`

This diff also updates the `flush` method so that a copy of the buffer is uploaded to s3 instead of `self.buffer`, and also calls `seek(0)` on the buffer copy so that the s3 file isn't empty