### PR TITLE
Improvements to make_histogram

### DIFF
--- a/tensorboardX/summary.py
+++ b/tensorboardX/summary.py
@@ -123,7 +123,7 @@ def scalar(name, scalar, collections=None):
     return Summary(value=[Summary.Value(tag=name, simple_value=scalar)])
 
 
-def histogram(name, values, bins, collections=None, max_bins=None):
+def histogram(name, values, bins, max_bins=None):
     # pylint: disable=line-too-long
     """Outputs a `Summary` protocol buffer with a histogram.
     The generated
@@ -135,8 +135,6 @@ def histogram(name, values, bins, collections=None, max_bins=None):
         TensorBoard.
       values: A real numeric `Tensor`. Any shape. Values to use to
         build the histogram.
-      collections: Optional list of graph collections keys. The new summary op is
-        added to these collections. Defaults to `[GraphKeys.SUMMARIES]`.
     Returns:
       A scalar `Tensor` of type `string`. The serialized `Summary` protocol
       buffer.

--- a/tensorboardX/summary.py
+++ b/tensorboardX/summary.py
@@ -168,15 +168,12 @@ def make_histogram(values, bins, max_bins=None):
 
     limits = limits[1:]
 
-    for i, c in enumerate(counts):
-        if c > 0:
-            start = max(0, i - 1)
-            break
-
-    for i, c in enumerate(reversed(counts)):
-        if c > 0:
-            end = counts.size - i
-            break
+    # Find the first and the last bin defining the support of the histogram:
+    cum_counts = np.cumsum(np.greater(counts, 0, dtype=np.int32))
+    start, end = np.searchsorted(cum_counts, [0, cum_counts[-1] - 1], side="right")
+    start = int(start) - 1
+    end = int(end) + 1
+    del cum_counts
 
     counts = counts[start:end]
     limits = limits[start:end]

--- a/tensorboardX/summary.py
+++ b/tensorboardX/summary.py
@@ -166,17 +166,19 @@ def make_histogram(values, bins, max_bins=None):
         new_limits[-1] = limits[-1]
         limits = new_limits
 
-    limits = limits[1:]
-
     # Find the first and the last bin defining the support of the histogram:
     cum_counts = np.cumsum(np.greater(counts, 0, dtype=np.int32))
     start, end = np.searchsorted(cum_counts, [0, cum_counts[-1] - 1], side="right")
-    start = int(start) - 1
+    start = int(start)
     end = int(end) + 1
     del cum_counts
 
-    counts = counts[start:end]
-    limits = limits[start:end]
+    # Tensorboard only includes the right bin limits. To still have the leftmost limit
+    # included, we include an empty bin left.
+    # If start == 0, we need to add an empty one left, otherwise we can just include the bin left to the
+    # first nonzero-count bin:
+    counts = counts[start - 1:end] if start > 0 else np.concatenate([[0], counts[:end]])
+    limits = limits[start:end + 1]
 
     if counts.size == 0 or limits.size == 0:
         raise ValueError('The histogram is empty, please file a bug report.')

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -387,7 +387,7 @@ class SummaryWriter(object):
             json.dump(self.scalar_dict, f)
         self.scalar_dict = {}
 
-    def add_histogram(self, tag, values, global_step=None, bins='tensorflow', walltime=None):
+    def add_histogram(self, tag, values, global_step=None, bins='tensorflow', walltime=None, max_bins=None):
         """Add histogram to summary.
 
         Args:
@@ -403,7 +403,7 @@ class SummaryWriter(object):
         if isinstance(bins, six.string_types) and bins == 'tensorflow':
             bins = self.default_bins
         self.file_writer.add_summary(
-            histogram(tag, values, bins), global_step, walltime)
+            histogram(tag, values, bins, max_bins=max_bins), global_step, walltime)
 
     def add_image(self, tag, img_tensor, global_step=None, walltime=None, dataformats='CHW'):
         """Add image data to summary.

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -773,8 +773,6 @@ class SummaryWriter(object):
     def close(self):
         if self.file_writer is None:
             return  # ignore double close
-        self.file_writer.flush()
-        self.file_writer.close()
         for path, writer in self.all_writers.items():
             writer.flush()
             writer.close()

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -49,3 +49,8 @@ class SummaryTest(unittest.TestCase):
 
     def test_text(self):
         summary.text('dummy', 'text 123')
+
+    def test_histogram(self):
+        summary.histogram('dummy', np.random.rand(1024), bins='auto', max_bins=5)
+        summary.histogram('dummy', np.random.rand(1024), bins='fd', max_bins=5)
+        summary.histogram('dummy', np.random.rand(1024), bins='doane', max_bins=5)


### PR DESCRIPTION
Please consider the following improvements to the make_histogram function:

- An option to limit the maximum number of bins, because it can become quite large for example with bins="fd"
- A more straightforward way to ensure that the leftmost bin edge is contained in the output (used to be the max(0, i - 1) line in the trimming
- A numpy version for better worst-case performance of the trimming of empty bins