### PR TITLE
Flush the record writers periodically

### DIFF
--- a/tensorboardX/event_file_writer.py
+++ b/tensorboardX/event_file_writer.py
@@ -124,13 +124,14 @@ class EventFileWriter(object):
     def reopen(self):
         """Reopens the EventFileWriter.
         Can be called after `close()` to add more events in the same directory.
-        The events will go into a new events file.
+        The events will go into a new events file and a new periodic flushing
+        t
         Does nothing if the EventFileWriter was not closed.
         """
         if self._closed:
             self._closed = False
             self._worker = _EventLoggerThread(
-                self._event_queue, self._ev_writer,flush_secs
+                self._event_queue, self._ev_writer, self.flush_secs
             )
             self._worker.start()
 
@@ -149,14 +150,13 @@ class EventFileWriter(object):
         """
         if not self._closed:
             self._event_queue.join()
-            self._ev_writer.flush()
 
     def close(self):
-        """Flushes the event file to disk and close the file.
-        Call this method when you do not need the summary writer anymore.
+        """Performs a final flush of the event file to disk, stops the
+        write/flush worker and closes the file. Call this method when you do not
+        need the summary writer anymore.
         """
         if not self._closed:
-            self.flush()
             self._worker.stop()
             self._ev_writer.close()
             self._closed = True

--- a/tensorboardX/event_file_writer.py
+++ b/tensorboardX/event_file_writer.py
@@ -124,9 +124,8 @@ class EventFileWriter(object):
     def reopen(self):
         """Reopens the EventFileWriter.
         Can be called after `close()` to add more events in the same directory.
-        The events will go into a new events file and a new periodic flushing
-        t
-        Does nothing if the EventFileWriter was not closed.
+        The events will go into a new events file and a new write/flush worker
+        is created. Does nothing if the EventFileWriter was not closed.
         """
         if self._closed:
             self._closed = False

--- a/tensorboardX/event_file_writer.py
+++ b/tensorboardX/event_file_writer.py
@@ -149,6 +149,7 @@ class EventFileWriter(object):
         """
         if not self._closed:
             self._event_queue.join()
+            self._ev_writer.flush()
 
     def close(self):
         """Performs a final flush of the event file to disk, stops the
@@ -156,6 +157,7 @@ class EventFileWriter(object):
         need the summary writer anymore.
         """
         if not self._closed:
+            self.flush()
             self._worker.stop()
             self._ev_writer.close()
             self._closed = True

--- a/tensorboardX/record_writer.py
+++ b/tensorboardX/record_writer.py
@@ -105,12 +105,10 @@ register_writer_factory("s3", S3RecordWriterFactory())
 
 
 class RecordWriter(object):
-    def __init__(self, path, flush_secs=2):
+    def __init__(self, path):
         self._name_to_tf_name = {}
         self._tf_names = set()
         self.path = path
-        # TODO. flush every flush_secs, not every time.
-        self.flush_secs = flush_secs
         self._writer = None
         self._writer = open_file(path)
 
@@ -121,6 +119,8 @@ class RecordWriter(object):
         w(struct.pack('I', masked_crc32c(header)))
         w(event_str)
         w(struct.pack('I', masked_crc32c(event_str)))
+
+    def flush(self):
         self._writer.flush()
 
     def close(self):


### PR DESCRIPTION
This PR allows the record writers to be flushed periodically every `flush_secs`, instead of flushing on every write.

There should be no issues with race conditions since the writes and flushes happen on one thread.

@orionr @lanpa 