### PR TITLE
Fix reshaping in _prepare_video

### DIFF
--- a/tensorboardX/utils.py
+++ b/tensorboardX/utils.py
@@ -60,8 +60,8 @@ def _prepare_video(V):
     n_rows = 2**((b.bit_length() - 1) // 2)
     n_cols = b // n_rows
 
-    V = np.reshape(V, newshape=(n_rows, n_cols, c, t, h, w))
-    V = np.transpose(V, axes=(3, 0, 4, 1, 5, 2))
+    V = np.reshape(V, newshape=(n_rows, n_cols, t, c, h, w))
+    V = np.transpose(V, axes=(2, 0, 4, 1, 5, 3))
     V = np.reshape(V, newshape=(t, n_rows * h, n_cols * w, c))
 
     return V

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,10 +3,11 @@ from tensorboardX import summary
 import numpy as np
 import pytest
 import unittest
-from tensorboardX.utils import make_grid
+from tensorboardX.utils import make_grid, _prepare_video
 
 class UtilsTest(unittest.TestCase):
     def test_to_HWC(self):
+        np.random.seed(1)
         test_image = np.random.randint(0, 256, size=(3, 32, 32), dtype=np.uint8)
         converted = convert_to_HWC(test_image, 'chw')
         assert converted.shape == (32, 32, 3)
@@ -16,6 +17,16 @@ class UtilsTest(unittest.TestCase):
         test_image = np.random.randint(0, 256, size=(32, 32), dtype=np.uint8)
         converted = convert_to_HWC(test_image, 'hw')
         assert converted.shape == (32, 32, 3)
+
+    def test_prepare_video(self):
+        # at each timestep the sum over all other dimensions of the video should stay the same
+        np.random.seed(1)
+        V_before = np.random.random((4, 10, 3, 20, 20))
+        V_after = _prepare_video(np.copy(V_before))
+        V_before = np.swapaxes(V_before, 0, 1)
+        V_before = np.reshape(V_before, newshape=(10,-1))
+        V_after = np.reshape(V_after, newshape=(10,-1))
+        np.testing.assert_array_almost_equal(np.sum(V_before, axis=1), np.sum(V_after, axis=1))
 
 def convert_to_HWC(tensor, input_format):  # tensor: numpy array
     assert(len(set(input_format)) == len(input_format)), "You can not use the same dimension shordhand twice."


### PR DESCRIPTION
When using `add_video` to render an animation, we got weird artifacts in the color channel, see https://github.com/david-lindner/safe-grid-gym/issues/18

I could trace it back to `utils._prepare_video`. It seems like a [recent commit](https://github.com/lanpa/tensorboardX/commit/342074a6bc29b03974fda3073af5e46bfa27cb0f#diff-795d2201d3d76369b7cd697098a85565R46), that changed the video API, caused the time and color dimensions to be swapped here. However, this change was not correctly integrated in the reshaping that happends at the end of the function.

This PR adds a test that shows the issue and fixes it by correcting the reshaping. 