### PR TITLE
Skip test_video if moviepy isn't installed

### DIFF
--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -44,6 +44,10 @@ class SummaryTest(unittest.TestCase):
         summary.image('dummy', np.random.rand(32, 32).astype(np.float32), dataformats='HW')
 
     def test_video(self):
+        try:
+            import moviepy
+        except ImportError:
+            return
         summary.video('dummy', np.random.rand(16, 48, 1, 28, 28).astype(np.float32))
 
     def test_audio(self):


### PR DESCRIPTION
We don't have moviepy installed internally, so want to skip this test in that case.