### PR TITLE
Make sure np array isn't passed to protobuf

### DIFF
--- a/tensorboardX/pytorch_graph.py
+++ b/tensorboardX/pytorch_graph.py
@@ -148,11 +148,11 @@ class Graph_py(object):
 
             if v.tensorSize and len(v.tensorSize) > 0:  # assume data is float32, only parameter is counted
                 node_stats.append(
-                  NodeExecStats(node_name=v.uniqueName,
-                                all_start_micros=int(time.time() * 1e7),
-                                all_end_rel_micros=42,
-                                memory=[AllocatorMemoryUsed(allocator_name="cpu",
-                                                            total_bytes=int(np.prod(v.tensorSize)) * 4)]))
+                    NodeExecStats(node_name=v.uniqueName,
+                                  all_start_micros=int(time.time() * 1e7),
+                                  all_end_rel_micros=42,
+                                  memory=[AllocatorMemoryUsed(allocator_name="cpu",
+                                                              total_bytes=int(np.prod(v.tensorSize)) * 4)]))
 
         return nodes, node_stats
 

--- a/tensorboardX/pytorch_graph.py
+++ b/tensorboardX/pytorch_graph.py
@@ -147,11 +147,12 @@ class Graph_py(object):
                                     attributes=v.attributes))
 
             if v.tensorSize and len(v.tensorSize) > 0:  # assume data is float32, only parameter is counted
-                node_stats.append(NodeExecStats(node_name=v.uniqueName,
-                                                all_start_micros=int(time.time() * 1e7),
-                                                all_end_rel_micros=42,
-                                                memory=[AllocatorMemoryUsed(allocator_name="cpu",
-                                                                            total_bytes=int(np.prod(v.tensorSize)) * 4)]))
+                node_stats.append(
+                  NodeExecStats(node_name=v.uniqueName,
+                                all_start_micros=int(time.time() * 1e7),
+                                all_end_rel_micros=42,
+                                memory=[AllocatorMemoryUsed(allocator_name="cpu",
+                                                            total_bytes=int(np.prod(v.tensorSize)) * 4)]))
 
         return nodes, node_stats
 

--- a/tensorboardX/pytorch_graph.py
+++ b/tensorboardX/pytorch_graph.py
@@ -151,7 +151,7 @@ class Graph_py(object):
                                                 all_start_micros=int(time.time() * 1e7),
                                                 all_end_rel_micros=42,
                                                 memory=[AllocatorMemoryUsed(allocator_name="cpu",
-                                                                            total_bytes=np.prod(v.tensorSize) * 4)]))
+                                                                            total_bytes=int(np.prod(v.tensorSize)) * 4)]))
 
         return nodes, node_stats
 


### PR DESCRIPTION
Fixes an issue we saw with protobuf 3.0.0b2 in fbcode.

Let's see if we can get a test around this protobuf version. Thanks for the help debugging!