### PR TITLE
Fix info: specifying srate in add_audio

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -99,11 +99,12 @@ complete example.
 
 Add audio
 ---------
-Currently the sampling rate of the this function is fixed at 44100 kHz, single
-channel. The input of the ``add_audio`` function is a one dimensional array, with
-each element representing the consecutive amplitude samples. For a 2 seconds
-audio, the input ``x`` should have 88200 elements. Each element should lie in
-[−1, 1].
+To log an single channel audio file, use ``add_audio(tag, audio, iteration, sample_rate)``.
+The input of the ``add_audio`` function is a one dimensional array, with
+each element representing the consecutive amplitude samples.
+For a 2 seconds audio with ``sample_rate`` 44100 Hz,
+the input ``x`` should have 88200 elements.
+Each element should lie in [−1, 1].
 
 Add embedding
 -------------

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -99,11 +99,8 @@ complete example.
 
 Add audio
 ---------
-To log an single channel audio file, use ``add_audio(tag, audio, iteration, sample_rate)``.
-The input of the ``add_audio`` function is a one dimensional array, with
-each element representing the consecutive amplitude samples.
-For a 2 seconds audio with ``sample_rate`` 44100 Hz,
-the input ``x`` should have 88200 elements.
+To log a single channel audio, use ``add_audio(tag, audio, iteration, sample_rate)``, where ``audio`` is an one dimensional array, and each element in the array represents the consecutive amplitude samples.
+For a 2 seconds audio with ``sample_rate`` 44100 Hz, the input ``x`` should have 88200 elements.
 Each element should lie in [−1, 1].
 
 Add embedding

--- a/docs/tutorial_zh.rst
+++ b/docs/tutorial_zh.rst
@@ -48,8 +48,8 @@ value 可以是 PyTorch tensor ， numpy或是 float，int 之類的python原生
 
 紀錄聲音
 -------------
-``writer.add_audio('myaudio', audio, iteration, 44100)``
-這功能只支援單聲道。 add_audio 要傳入的聲音資訊是個一維陣列，陣列的每一個元素代表在每一個取樣點的振幅大小。取樣頻率為 44100 kHz 的情況下。一段2秒鐘的聲音應該要有88200個點；注意其中每個元素的值應該都介於正負1之間。
+``writer.add_audio('myaudio', audio, iteration, sample_rate)``
+這功能只支援單聲道。 add_audio 要傳入的聲音資訊是個一維陣列，陣列的每一個元素代表在每一個取樣點的振幅大小。取樣頻率(sample_rate)為 44100 kHz 的情況下。一段2秒鐘的聲音應該要有88200個點；注意其中每個元素的值應該都介於正負1之間。
 
 紀錄文字
 -------------


### PR DESCRIPTION
Currently, we can specify sampling rate in method `add_audio`.

By the way, we also have to fix Chinese version(docs/tutorial_zh.rst) of this document. Can someone help us?