### PR TITLE
Avoid call to struct.pack in loop in audio()

### DIFF
--- a/tensorboardX/summary.py
+++ b/tensorboardX/summary.py
@@ -373,8 +373,7 @@ def audio(tag, tensor, sample_rate=44100):
     Wave_write.setsampwidth(2)
     Wave_write.setframerate(sample_rate)
     tensor_enc = b''
-    for v in tensor_list:
-        tensor_enc += struct.pack('<h', v)
+    tensor_enc += struct.pack("<" + "h" * len(tensor_list), *tensor_list)
 
     Wave_write.writeframes(tensor_enc)
     Wave_write.close()


### PR DESCRIPTION
Speeds up by 2x for 1 sec audio, 50x for 1 min audio (says 100x in commit message but actually 50x)

Old way: 
```
$ python -m timeit -s "from tensorboardX import SummaryWriter; writer = SummaryWriter(); import numpy as np; sound = (np.random.random(16000) -0.5) * 2;" "writer.add_audio('test', sound, 0, sample_rate=16000)"
10 loops, best of 3: 36.3 msec per loop
$ python -m timeit -s "from tensorboardX import SummaryWriter; writer = SummaryWriter(); import numpy as np; sound = (np.random.random(16000*60) -0.5) * 2;" "writer.add_audio('test', sound, 0, sample_rate=16000)"
10 loops, best of 3: 65.2 sec per loop
```
New way:
```
$ python -m timeit -s "from tensorboardX import SummaryWriter; writer = SummaryWriter(); import numpy as np; sound = (np.random.random(16000) -0.5) * 2;" "writer.add_audio('test', sound, 0, sample_rate=16000)"
10 loops, best of 3: 16.4 msec per loop
$ python -m timeit -s "from tensorboardX import SummaryWriter; writer = SummaryWriter(); import numpy as np; sound = (np.random.random(16000*60) -0.5) * 2;" "writer.add_audio('test', sound, 0, sample_rate=16000)"
10 loops, best of 3: 1.26 sec per loop
```