### PR TITLE
Optionally use crc32c library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ install:
   - pip install boto3
   - pip install moto
   - pip install visdom
+  - pip install crc32c
   - conda install ffmpeg
   - conda list
   - python -c "import imageio; imageio.plugins.ffmpeg.download()"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ or build from source:
 
 `git clone https://github.com/lanpa/tensorboardX && cd tensorboardX && python setup.py install`
 
+You can optionally install [`crc32c`](https://github.com/ICRAR/crc32c) to speed up saving a large amount of data.
+
 
 ## Example
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ requirements = [
 
 test_requirements = [
     'pytest',
-    'matplotlib'
+    'matplotlib',
+    'crc32c',
 ]
 
 setup(

--- a/tensorboardX/crc32c.py
+++ b/tensorboardX/crc32c.py
@@ -1,5 +1,21 @@
 # https://www.ietf.org/rfc/rfc3309.txt
 import array
+import os
+
+try:
+    if os.environ.get('CRC32C_SW_MODE', None) is None:
+        os.environ['CRC32C_SW_MODE'] = 'auto'
+    from crc32c import crc32 as _crc32_ext
+
+
+    def _crc32c_native(data):
+        x = _crc32_ext(data) & 0xffffffff
+        a = (x >> 15) & 0xffffffff
+        b = (x << 17) & 0xffffffff
+        out = ((a | b) + 0xa282ead8) & 0xffffffff
+        return out
+except ImportError:
+    _crc32c_native = None
 
 
 CRC_TABLE = (
@@ -69,7 +85,6 @@ CRC_TABLE = (
     0xbe2da0a5, 0x4c4623a6, 0x5f16d052, 0xad7d5351,
 )
 
-
 CRC_INIT = 0
 
 _MASK = 0xFFFFFFFF
@@ -112,7 +127,7 @@ def crc_finalize(crc):
     return crc & _MASK
 
 
-def crc32c(data):
+def _crc32c(data):
     """Compute CRC-32C checksum of the data.
 
     Args:
@@ -122,3 +137,6 @@ def crc32c(data):
       32-bit CRC-32C checksum of data as long.
     """
     return crc_finalize(crc_update(CRC_INIT, data))
+
+
+crc32c = _crc32c if _crc32c_native is None else _crc32c_native

--- a/tensorboardX/crc32c.py
+++ b/tensorboardX/crc32c.py
@@ -5,15 +5,7 @@ import os
 try:
     if os.environ.get('CRC32C_SW_MODE', None) is None:
         os.environ['CRC32C_SW_MODE'] = 'auto'
-    from crc32c import crc32 as _crc32_ext
-
-
-    def _crc32c_native(data):
-        x = _crc32_ext(data) & 0xffffffff
-        a = (x >> 15) & 0xffffffff
-        b = (x << 17) & 0xffffffff
-        out = ((a | b) + 0xa282ead8) & 0xffffffff
-        return out
+    from crc32c import crc32 as _crc32c_native
 except ImportError:
     _crc32c_native = None
 

--- a/tests/test_crc32c.py
+++ b/tests/test_crc32c.py
@@ -1,0 +1,15 @@
+import unittest
+from secrets import token_bytes
+from tensorboardX.crc32c import _crc32c, _crc32c_native
+
+
+class CRC32CTest(unittest.TestCase):
+    def test_crc32c(self):
+        data = b'abcd'
+        assert _crc32c(data) == 0x92c80a31
+
+    def test_implementations(self):
+        random_data = token_bytes(100)
+        a = _crc32c(random_data)
+        b = _crc32c_native(random_data)
+        assert a == b

--- a/tests/test_crc32c.py
+++ b/tests/test_crc32c.py
@@ -1,15 +1,18 @@
 import unittest
-from secrets import token_bytes
-from tensorboardX.crc32c import _crc32c, _crc32c_native
+from tensorboardX.crc32c import _crc32c, _crc32c_native, crc32c
 
 
 class CRC32CTest(unittest.TestCase):
     def test_crc32c(self):
         data = b'abcd'
+        assert crc32c(data) == 0x92c80a31
+
+    def test_crc32c_python(self):
+        data = b'abcd'
         assert _crc32c(data) == 0x92c80a31
 
-    def test_implementations(self):
-        random_data = token_bytes(100)
-        a = _crc32c(random_data)
-        b = _crc32c_native(random_data)
-        assert a == b
+    def test_crc32c_native(self):
+        if _crc32c_native is None:
+            return
+        data = b'abcd'
+        assert _crc32c_native(data) == 0x92c80a31


### PR DESCRIPTION
- If crc32c library with native implementation is not presented, use the current implementation.
- If crc32c library is presented try to use SSE instructions or a software implementation in C ("auto" mode)
- Don't add crc32c to the requirements list to make the dependency optional.

See #428 for details.