### PR TITLE
Support numpy array for label_img of add_embedding

### DIFF
--- a/tensorboardX/embedding.py
+++ b/tensorboardX/embedding.py
@@ -29,7 +29,7 @@ def make_sprite(label_img, save_path):
     from PIL import Image
     # this ensures the sprite image has correct dimension as described in
     # https://www.tensorflow.org/get_started/embedding_viz
-    nrow = int(math.ceil((label_img.size(0)) ** 0.5))
+    nrow = int(math.ceil((label_img.shape[0]) ** 0.5))
     arranged_img_CHW = make_grid(make_np(label_img), ncols=nrow)
 
     # augment images so that #images equals nrow*nrow
@@ -54,8 +54,8 @@ def append_pbtxt(metadata, label_img, save_path, subdir, global_step, tag):
         if label_img is not None:
             f.write('sprite {\n')
             f.write('image_path: "{}"\n'.format(join(subdir, 'sprite.png')))
-            f.write('single_image_dim: {}\n'.format(label_img.size(3)))
-            f.write('single_image_dim: {}\n'.format(label_img.size(2)))
+            f.write('single_image_dim: {}\n'.format(label_img.shape[3]))
+            f.write('single_image_dim: {}\n'.format(label_img.shape[2]))
             f.write('}\n')
         f.write('}\n')
 

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -809,7 +809,7 @@ class SummaryWriter(object):
         Args:
             mat (torch.Tensor or numpy.array): A matrix which each row is the feature vector of the data point
             metadata (list): A list of labels, each element will be convert to string
-            label_img (torch.Tensor): Images correspond to each data point
+            label_img (torch.Tensor or numpy.array): Images correspond to each data point
             global_step (int): Global step value to record
             tag (string): Name for the embedding
         Shape:

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -809,7 +809,7 @@ class SummaryWriter(object):
         Args:
             mat (torch.Tensor or numpy.array): A matrix which each row is the feature vector of the data point
             metadata (list): A list of labels, each element will be convert to string
-            label_img (torch.Tensor or numpy.array): Images correspond to each data point
+            label_img (torch.Tensor or numpy.array): Images correspond to each data point. Each image should be square.
             global_step (int): Global step value to record
             tag (string): Name for the embedding
         Shape:


### PR DESCRIPTION
`add_embedding` takes `label_img` but it's PyTorch tensor only.
I changed it to support numpy arrays.

I'm creating tensorboardX wrapper for Swift for TensorFlow.
https://github.com/t-ae/tensorboardx-s4tf
I want to support `add_embedding` without adding PyTorch dependency :)