### PR TITLE
Example adding various images

### DIFF
--- a/examples/demo_image.py
+++ b/examples/demo_image.py
@@ -1,0 +1,57 @@
+import io
+import urllib
+
+import numpy as np
+from PIL import Image, ImageDraw
+
+from tensorboardX import SummaryWriter
+from tensorboardX.proto.summary_pb2 import Summary
+
+writer = SummaryWriter()
+
+# Generated image - 'HWD' format
+
+blue = Image.new('RGB', (240, 240), color='blue')
+writer.add_image('blue', np.asarray(blue), dataformats='HWD')
+
+# PNG file - 'HWC' format
+
+screenshot = Image.open('../screenshots/scalar.png')
+writer.add_image('screenshot', np.asarray(screenshot), dataformats='HWC')
+
+# JPG format - 'HWD' format
+
+url = ('https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/'
+       'Cyanocitta_cristata_blue_jay.jpg/792px-Cyanocitta_cristata_blue_jay.jpg')
+jay = Image.open(urllib.urlopen(url))
+writer.add_image('jay', np.asarray(jay), dataformats='HWD')
+
+# Avoid round-trip (image -> array -> image) by adding summary directly
+
+def summary_image(img):
+    output = io.BytesIO()
+    img.save(output, format='PNG')
+    encoded = output.getvalue()
+    output.close()
+    return Summary.Image(
+        height=img.height,
+        width=img.width,
+        colorspace=len(img.getbands()),
+        encoded_image_string=encoded)
+
+def add_image(writer, tag, img):
+    summary = Summary(value=[Summary.Value(tag=tag, image=summary_image(img))])
+    writer.file_writer.add_summary(summary)
+
+# Detection bounding box
+
+jay_detect = jay.copy()
+ImageDraw.Draw(jay_detect).rectangle(((505, 154), (550, 204)), outline="white")
+add_image(writer, "jay-detect", jay_detect)
+
+# Flip
+
+screenshot_flipped = screenshot.transpose(Image.FLIP_LEFT_RIGHT)
+add_image(writer, "screenshot-flipped", screenshot_flipped)
+
+writer.close()

--- a/tensorboardX/proto/plugin_mesh.proto
+++ b/tensorboardX/proto/plugin_mesh.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package tensorboard.mesh;
+package tensorboardX.mesh;
 
 // A MeshPluginData encapsulates information on which plugins are able to make
 // use of a certain summary value.

--- a/tensorboardX/proto/plugin_mesh_pb2.py
+++ b/tensorboardX/proto/plugin_mesh_pb2.py
@@ -16,17 +16,17 @@ _sym_db = _symbol_database.Default()
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='tensorboardX/proto/plugin_mesh.proto',
-  package='tensorboard.mesh',
+  package='tensorboardX.mesh',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n$tensorboardX/proto/plugin_mesh.proto\x12\x10tensorboard.mesh\"\xd6\x01\n\x0eMeshPluginData\x12\x0f\n\x07version\x18\x01 \x01(\x05\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x42\n\x0c\x63ontent_type\x18\x03 \x01(\x0e\x32,.tensorboard.mesh.MeshPluginData.ContentType\x12\x13\n\x0bjson_config\x18\x05 \x01(\t\x12\r\n\x05shape\x18\x06 \x03(\x05\"=\n\x0b\x43ontentType\x12\r\n\tUNDEFINED\x10\x00\x12\n\n\x06VERTEX\x10\x01\x12\x08\n\x04\x46\x41\x43\x45\x10\x02\x12\t\n\x05\x43OLOR\x10\x03\x62\x06proto3')
+  serialized_pb=_b('\n$tensorboardX/proto/plugin_mesh.proto\x12\x11tensorboardX.mesh\"\xd7\x01\n\x0eMeshPluginData\x12\x0f\n\x07version\x18\x01 \x01(\x05\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x43\n\x0c\x63ontent_type\x18\x03 \x01(\x0e\x32-.tensorboardX.mesh.MeshPluginData.ContentType\x12\x13\n\x0bjson_config\x18\x05 \x01(\t\x12\r\n\x05shape\x18\x06 \x03(\x05\"=\n\x0b\x43ontentType\x12\r\n\tUNDEFINED\x10\x00\x12\n\n\x06VERTEX\x10\x01\x12\x08\n\x04\x46\x41\x43\x45\x10\x02\x12\t\n\x05\x43OLOR\x10\x03\x62\x06proto3')
 )
 
 
 
 _MESHPLUGINDATA_CONTENTTYPE = _descriptor.EnumDescriptor(
   name='ContentType',
-  full_name='tensorboard.mesh.MeshPluginData.ContentType',
+  full_name='tensorboardX.mesh.MeshPluginData.ContentType',
   filename=None,
   file=DESCRIPTOR,
   values=[
@@ -49,49 +49,49 @@ _MESHPLUGINDATA_CONTENTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=212,
-  serialized_end=273,
+  serialized_start=214,
+  serialized_end=275,
 )
 _sym_db.RegisterEnumDescriptor(_MESHPLUGINDATA_CONTENTTYPE)
 
 
 _MESHPLUGINDATA = _descriptor.Descriptor(
   name='MeshPluginData',
-  full_name='tensorboard.mesh.MeshPluginData',
+  full_name='tensorboardX.mesh.MeshPluginData',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='version', full_name='tensorboard.mesh.MeshPluginData.version', index=0,
+      name='version', full_name='tensorboardX.mesh.MeshPluginData.version', index=0,
       number=1, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='name', full_name='tensorboard.mesh.MeshPluginData.name', index=1,
+      name='name', full_name='tensorboardX.mesh.MeshPluginData.name', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='content_type', full_name='tensorboard.mesh.MeshPluginData.content_type', index=2,
+      name='content_type', full_name='tensorboardX.mesh.MeshPluginData.content_type', index=2,
       number=3, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='json_config', full_name='tensorboard.mesh.MeshPluginData.json_config', index=3,
+      name='json_config', full_name='tensorboardX.mesh.MeshPluginData.json_config', index=3,
       number=5, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='shape', full_name='tensorboard.mesh.MeshPluginData.shape', index=4,
+      name='shape', full_name='tensorboardX.mesh.MeshPluginData.shape', index=4,
       number=6, type=5, cpp_type=1, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -110,8 +110,8 @@ _MESHPLUGINDATA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=59,
-  serialized_end=273,
+  serialized_start=60,
+  serialized_end=275,
 )
 
 _MESHPLUGINDATA.fields_by_name['content_type'].enum_type = _MESHPLUGINDATA_CONTENTTYPE
@@ -122,7 +122,7 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 MeshPluginData = _reflection.GeneratedProtocolMessageType('MeshPluginData', (_message.Message,), dict(
   DESCRIPTOR = _MESHPLUGINDATA,
   __module__ = 'tensorboardX.proto.plugin_mesh_pb2'
-  # @@protoc_insertion_point(class_scope:tensorboard.mesh.MeshPluginData)
+  # @@protoc_insertion_point(class_scope:tensorboardX.mesh.MeshPluginData)
   ))
 _sym_db.RegisterMessage(MeshPluginData)
 


### PR DESCRIPTION
This is inspired by #21, which wants a way to easily add a PNG as an image summary. The examples demonstrate how to do this.

FWIW I think this example is a very reasonable feature addition:

    writer.add_image('sample', 'sample.png')

The rationale for closing #21 was that this sort of encoding is best left to the user. I disagree based on the following:

1. tensorboardX [already uses a PIL.Image instance to encode a numpy array to PNG bytes](https://github.com/lanpa/tensorboardX/blob/366bc8ff960a1d674feb8a844da187222103251e/tensorboardX/summary.py#L307-L319)

2. If given a PIL.Image instance, tensorboardX can skip the step of generating one from the numpy array (this is [shown in the example](https://github.com/gar1t/tensorboardX/blob/master/examples/demo_image.py#L31-L44))

3. If given a string value as the second argument to `writer.add_image`, tensorboardX can trivially call `PIL.Image.open` and use that image instance to encode the PNG bytes for the summary

This PR is valid as a stand-alone example, but I also hope it makes the case to support the following enhancements to `writer.add_image`:

- Support a string arg for image, which is used in a call to `PIL.Image.open`
- Support a PIL Image instance directly

I'm happy to implement those changes in another PR but I wanted to start this discussion with an example (useful in its own right).