### PR TITLE
Example adding various images

### DIFF
--- a/examples/demo_image.py
+++ b/examples/demo_image.py
@@ -1,0 +1,57 @@
+import io
+import urllib
+
+import numpy as np
+from PIL import Image, ImageDraw
+
+from tensorboardX import SummaryWriter
+from tensorboardX.proto.summary_pb2 import Summary
+
+writer = SummaryWriter()
+
+# Generated image - 'HWD' format
+
+blue = Image.new('RGB', (240, 240), color='blue')
+writer.add_image('blue', np.asarray(blue), dataformats='HWD')
+
+# PNG file - 'HWC' format
+
+screenshot = Image.open('../screenshots/scalar.png')
+writer.add_image('screenshot', np.asarray(screenshot), dataformats='HWC')
+
+# JPG format - 'HWD' format
+
+url = ('https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/'
+       'Cyanocitta_cristata_blue_jay.jpg/792px-Cyanocitta_cristata_blue_jay.jpg')
+jay = Image.open(urllib.urlopen(url))
+writer.add_image('jay', np.asarray(jay), dataformats='HWD')
+
+# Avoid round-trip (image -> array -> image) by adding summary directly
+
+def summary_image(img):
+    output = io.BytesIO()
+    img.save(output, format='PNG')
+    encoded = output.getvalue()
+    output.close()
+    return Summary.Image(
+        height=img.height,
+        width=img.width,
+        colorspace=len(img.getbands()),
+        encoded_image_string=encoded)
+
+def add_image(writer, tag, img):
+    summary = Summary(value=[Summary.Value(tag=tag, image=summary_image(img))])
+    writer.file_writer.add_summary(summary)
+
+# Detection bounding box
+
+jay_detect = jay.copy()
+ImageDraw.Draw(jay_detect).rectangle(((505, 154), (550, 204)), outline="white")
+add_image(writer, "jay-detect", jay_detect)
+
+# Flip
+
+screenshot_flipped = screenshot.transpose(Image.FLIP_LEFT_RIGHT)
+add_image(writer, "screenshot-flipped", screenshot_flipped)
+
+writer.close()


### PR DESCRIPTION
This is inspired by #21, which wants a way to easily add a PNG as an image summary. The examples demonstrate how to do this.

FWIW I think this example is a very reasonable feature addition:

    writer.add_image('sample', 'sample.png')

The rationale for closing #21 was that this sort of encoding is best left to the user. I disagree based on the following:

1. tensorboardX [already uses a PIL.Image instance to encode a numpy array to PNG bytes](https://github.com/lanpa/tensorboardX/blob/366bc8ff960a1d674feb8a844da187222103251e/tensorboardX/summary.py#L307-L319)

2. If given a PIL.Image instance, tensorboardX can skip the step of generating one from the numpy array (this is [shown in the example](https://github.com/gar1t/tensorboardX/blob/master/examples/demo_image.py#L31-L44))

3. If given a string value as the second argument to `writer.add_image`, tensorboardX can trivially call `PIL.Image.open` and use that image instance to encode the PNG bytes for the summary

This PR is valid as a stand-alone example, but I also hope it makes the case to support the following enhancements to `writer.add_image`:

- Support a string arg for image, which is used in a call to `PIL.Image.open`
- Support a PIL Image instance directly

I'm happy to implement those changes in another PR but I wanted to start this discussion with an example (useful in its own right).