### PR TITLE
Fix issue 108

### DIFF
--- a/tensorboardX/event_file_writer.py
+++ b/tensorboardX/event_file_writer.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import atexit
 import os
 import socket
 import threading
@@ -123,9 +124,14 @@ class EventFileWriter(object):
                 # exit after the thread has already been terminated earlier
                 # in the code.
                 EventFileWriter._close(obj)
-        self._thread_finalizer = weakref.finalize(self._worker,
-                                                  thread_finalizer,
-                                                  weakref.ref(self))
+        if hasattr(weakref, 'finalize'):
+            # Python 3
+            self._thread_finalizer = weakref.finalize(self._worker,
+                                                      thread_finalizer,
+                                                      weakref.ref(self))
+        else:
+            # Python 2
+            atexit.register(thread_finalizer, weakref.ref(self))
         self._worker.start()
 
     def get_logdir(self):

--- a/tensorboardX/event_file_writer.py
+++ b/tensorboardX/event_file_writer.py
@@ -214,8 +214,8 @@ class _EventLoggerThread(threading.Thread):
         # script. Instead, a weakref finalizer ensures clean termination
         # of this thread at exit before the rest of the environment is torn
         # down. If this thread were not a daemon, the user would have to
-        # manuallycall close() on the summary writer that spawns this thread 
-        # in orderto terminate it and allow the main process to exit at the 
+        # manually call close() on the summary writer that spawns this thread 
+        # in order to terminate it and allow the main process to exit at the 
         # end of a script.
         self.daemon = True
         self._queue = queue


### PR DESCRIPTION
Heya, I noticed that I hit issue #108 when I encountered its side-effect of causing my script to hang on exit. To avoid a hang, the flusher thread no longer joins itself! However, since the thread is a `daemon`, some `weakref.finalizer` magic is used to wait for a clean shutdown of the thread and then have the event writer flush to disk, on exit. The finalizer uses a weak reference to the event writer so as to not prevent the writer (and thread) from being garbage collected before the end of the script.

Issue #108 shows that event files are not closed on exit. This is fixed here.