### PR TITLE
Customize hparams display: add name of run, add epoch of metric measure

### DIFF
--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -322,7 +322,7 @@ class SummaryWriter(object):
             self.all_writers = {self.file_writer.get_logdir(): self.file_writer}
         return self.file_writer
 
-    def add_hparams(self, hparam_dict=None, metric_dict=None, name=str(time.time())), global_step = None)):
+    def add_hparams(self, hparam_dict=None, metric_dict=None, name=None, global_step = None)):
         """Add a set of hyperparameters to be compared in tensorboard.
 
         Args:
@@ -334,6 +334,7 @@ class SummaryWriter(object):
               you added by `add_scalar` will be displayed in hparam plugin. In most
               cases, this is unwanted.
             name (string): Personnalised name of the hparam session
+            global_step (int): Current time step
 
         Examples::
 
@@ -352,6 +353,9 @@ class SummaryWriter(object):
             raise TypeError('hparam_dict and metric_dict should be dictionary.')
         exp, ssi, sei = hparams(hparam_dict, metric_dict)
 
+        if not name:
+            name = str(time.time()))
+            
         with SummaryWriter(logdir=os.path.join(self.file_writer.get_logdir(), name) as w_hp:
             w_hp.file_writer.add_summary(exp)
             w_hp.file_writer.add_summary(ssi)

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -322,7 +322,7 @@ class SummaryWriter(object):
             self.all_writers = {self.file_writer.get_logdir(): self.file_writer}
         return self.file_writer
 
-    def add_hparams(self, hparam_dict=None, metric_dict=None):
+    def add_hparams(self, hparam_dict=None, metric_dict=None, name=str(time.time()))):
         """Add a set of hyperparameters to be compared in tensorboard.
 
         Args:
@@ -333,6 +333,7 @@ class SummaryWriter(object):
               here should be unique in the tensorboard record. Otherwise the value
               you added by `add_scalar` will be displayed in hparam plugin. In most
               cases, this is unwanted.
+            name (string): Personnalised name of the hparam session
 
         Examples::
 
@@ -351,7 +352,7 @@ class SummaryWriter(object):
             raise TypeError('hparam_dict and metric_dict should be dictionary.')
         exp, ssi, sei = hparams(hparam_dict, metric_dict)
 
-        with SummaryWriter(logdir=os.path.join(self.file_writer.get_logdir(), str(time.time()))) as w_hp:
+        with SummaryWriter(logdir=os.path.join(self.file_writer.get_logdir(), name) as w_hp:
             w_hp.file_writer.add_summary(exp)
             w_hp.file_writer.add_summary(ssi)
             w_hp.file_writer.add_summary(sei)

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -322,7 +322,7 @@ class SummaryWriter(object):
             self.all_writers = {self.file_writer.get_logdir(): self.file_writer}
         return self.file_writer
 
-    def add_hparams(self, hparam_dict=None, metric_dict=None, name=str(time.time()))):
+    def add_hparams(self, hparam_dict=None, metric_dict=None, name=str(time.time())), global_step = None)):
         """Add a set of hyperparameters to be compared in tensorboard.
 
         Args:
@@ -357,7 +357,7 @@ class SummaryWriter(object):
             w_hp.file_writer.add_summary(ssi)
             w_hp.file_writer.add_summary(sei)
             for k, v in metric_dict.items():
-                w_hp.add_scalar(k, v)
+                w_hp.add_scalar(k, v, global_step)
 
     def add_scalar(self, tag, scalar_value, global_step=None, walltime=None):
         """Add scalar data to summary.

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -356,7 +356,7 @@ class SummaryWriter(object):
         if not name:
             name = str(time.time()))
             
-        with SummaryWriter(logdir=os.path.join(self.file_writer.get_logdir(), name) as w_hp:
+        with SummaryWriter(logdir=os.path.join(self.file_writer.get_logdir(), name)) as w_hp:
             w_hp.file_writer.add_summary(exp)
             w_hp.file_writer.add_summary(ssi)
             w_hp.file_writer.add_summary(sei)


### PR DESCRIPTION
This modification allows the user to select the haparam session group name he wants, instead of just using the date as a session id. 

The session name can be made more legible, see below.

![image](https://user-images.githubusercontent.com/22726840/64766221-f916ee00-d545-11e9-8bbe-a5a8054d9a69.png)
