### PR TITLE
Add option for the s3 writer to get endpoint url from an environment variable

### DIFF
--- a/tensorboardX/record_writer.py
+++ b/tensorboardX/record_writer.py
@@ -3,6 +3,7 @@ To write tf_record into file. Here we use it for tensorboard's event writting.
 The code was borrowed from https://github.com/TeamHG-Memex/tensorboard_logger
 """
 
+import os
 import copy
 import io
 import os.path
@@ -79,7 +80,7 @@ class S3RecordWriter(object):
         self.buffer.write(val)
 
     def flush(self):
-        s3 = boto3.client('s3')
+        s3 = boto3.client('s3', endpoint_url=os.environ.get('S3_ENDPOINT'))
         bucket, path = self.bucket_and_path()
         upload_buffer = copy.copy(self.buffer)
         upload_buffer.seek(0)


### PR DESCRIPTION
Now the s3 client can get the endpoint url from the environment variable `S3_ENDPOINT` (this name is consistent with tensorflow: https://github.com/tensorflow/examples/blob/master/community/en/docs/deploy/s3.md).

This enables usage with tools like MinIO.