### PR TITLE
Google Cloud Storage support

### DIFF
--- a/tensorboardX/record_writer.py
+++ b/tensorboardX/record_writer.py
@@ -27,7 +27,8 @@ _VALID_OP_NAME_PART = re.compile('[A-Za-z0-9_.\\-/]+')
 
 # Registry of writer factories by prefix backends.
 #
-# Currently supports "s3://" URLs for S3 based on boto and falls
+# Currently supports "s3://" URLs for S3 based on boto,
+# "gs://" URLs for Google Cloud Storage and falls
 # back to local filesystem.
 REGISTERED_FACTORIES = {}
 
@@ -114,7 +115,8 @@ class GCSRecordWriter(object):
 
     def __init__(self, path):
         if not GCS_ENABLED:
-            raise ImportError("google cloud must be installed for GCS support.")
+            raise ImportError("google cloud must be installed for "
+                              "Google Cloud Storage support.")
 
         self.path = path
         self.buffer = io.BytesIO()
@@ -152,7 +154,7 @@ class GCSRecordWriter(object):
 
 
 class GCSRecordWriterFactory(object):
-    """Factory for event protocol buffer files to GCS."""
+    """Factory for event protocol buffer files to Google Cloud Storage."""
 
     def open(self, path):
         return GCSRecordWriter(path)

--- a/tensorboardX/record_writer.py
+++ b/tensorboardX/record_writer.py
@@ -115,8 +115,8 @@ class GCSRecordWriter(object):
 
     def __init__(self, path):
         if not GCS_ENABLED:
-            raise ImportError("google cloud must be installed for "
-                              "Google Cloud Storage support.")
+            raise ImportError("`google-cloud-storage` must be installed in order to use "
+                              "the 'gs://' protocol")
 
         self.path = path
         self.buffer = io.BytesIO()


### PR DESCRIPTION
This PR adds a writer factory that supports URLs on Google Cloud Storage, i.e. `gs://<bucket>/<path>`.

At the moment, I have not added any tests due to the fact that Google storage does not support any mocking. I could provide tests against a live bucket, but it would require each tester to have such a bucket available in order to run them.

## Relevant issues/PRs

This PR is a proper implementation of https://github.com/lanpa/tensorboardX/pull/388 that does not require importing tensorflow, however it requires [google-cloud-storage](https://pypi.org/project/google-cloud-storage/) to be installed.