### PR TITLE
Upload embedding to cloud storage

### DIFF
--- a/examples/demo_embedding.py
+++ b/examples/demo_embedding.py
@@ -60,6 +60,9 @@ num_epochs = 20
 embedding_log = 5
 writer = SummaryWriter(comment='mnist_embedding_training')
 
+#writer = SummaryWriter("gs://your-bucket/embedding-test")
+#writer = SummaryWriter("s3://your-bucket/embedding-test")
+
 # TRAIN
 for epoch in range(num_epochs):
     for j, sample in enumerate(gen):

--- a/tensorboardX/embedding.py
+++ b/tensorboardX/embedding.py
@@ -1,8 +1,35 @@
 import os
+import sys
 
 # Maximum sprite size allowed by TB frontend,
 # see https://github.com/lanpa/tensorboardX/issues/516
 TB_MAX_SPRITE_SIZE = 8192
+
+def maybe_upload_file(local_path):
+    '''Upload a file to remote cloud storage.'''
+    if local_path.startswith(('s3://', 'gs://')):
+        prefix = local_path.split(':')[0]
+        remote_bucket_path = local_path[len("s3://"):]  # same length
+        bp = remote_bucket_path.split("/")
+        bucket = bp[0]
+        path = remote_bucket_path[1 + len(bucket):]
+
+        # s3://example/file becomes s3:/example/file in Linux
+        local_path = prefix + ':/' + remote_bucket_path
+        if prefix == 's3':
+            import boto3
+            s3 = boto3.client('s3', endpoint_url=os.environ.get('S3_ENDPOINT'))
+            s3.upload_file(local_path, bucket, path)
+
+        elif prefix == 'gs':
+            from google.cloud import storage
+            client = storage.Client()
+
+            Hbucket = storage.Bucket(client, bucket)
+            blob = storage.Blob(path, Hbucket)
+            blob.upload_from_filename(local_path)
+
+
 
 def make_tsv(metadata, save_path, metadata_header=None):
     if not metadata_header:
@@ -12,15 +39,18 @@ def make_tsv(metadata, save_path, metadata_header=None):
             'len of header must be equal to the number of columns in metadata'
         metadata = ['\t'.join(str(e) for e in l)
                     for l in [metadata_header] + metadata]
-    import sys
+
+    named_path = os.path.join(save_path, 'metadata.tsv')
+
     if sys.version_info[0] == 3:
-        with open(os.path.join(save_path, 'metadata.tsv'), 'w', encoding='utf8') as f:
+        with open(named_path, 'w', encoding='utf8') as f:
             for x in metadata:
                 f.write(x + '\n')
     else:
-        with open(os.path.join(save_path, 'metadata.tsv'), 'wb') as f:
+        with open(named_path, 'wb') as f:
             for x in metadata:
                 f.write((x + '\n').encode('utf-8'))
+    maybe_upload_file(named_path)
 
 
 # https://github.com/tensorflow/tensorboard/issues/44 image label will be squared
@@ -52,12 +82,15 @@ def make_sprite(label_img, save_path):
     arranged_augment_square_HWC = np.ndarray((sprite_size, sprite_size, 3))
     arranged_augment_square_HWC[:arranged_img_HWC.shape[0], :, :] = arranged_img_HWC
     im = Image.fromarray(np.uint8((arranged_augment_square_HWC * 255).clip(0, 255)))
-    im.save(os.path.join(save_path, 'sprite.png'))
+    named_path = os.path.join(save_path, 'sprite.png')
+    im.save(named_path)
+    maybe_upload_file(named_path)
 
 
 def append_pbtxt(metadata, label_img, save_path, subdir, global_step, tag):
     from posixpath import join
-    with open(os.path.join(save_path, 'projector_config.pbtxt'), 'a') as f:
+    named_path = os.path.join(save_path, 'projector_config.pbtxt')
+    with open(named_path, 'a') as f:
         # step = os.path.split(save_path)[-1]
         f.write('embeddings {\n')
         f.write('tensor_name: "{}:{}"\n'.format(
@@ -73,10 +106,13 @@ def append_pbtxt(metadata, label_img, save_path, subdir, global_step, tag):
             f.write('single_image_dim: {}\n'.format(label_img.shape[2]))
             f.write('}\n')
         f.write('}\n')
+    maybe_upload_file(named_path)
 
 
 def make_mat(matlist, save_path):
-    with open(os.path.join(save_path, 'tensors.tsv'), 'w') as f:
+    named_path = os.path.join(save_path, 'tensors.tsv')
+    with open(named_path, 'w') as f:
         for x in matlist:
             x = [str(i.item()) for i in x]
             f.write('\t'.join(x) + '\n')
+    maybe_upload_file(named_path)

--- a/tensorboardX/embedding.py
+++ b/tensorboardX/embedding.py
@@ -6,7 +6,9 @@ import sys
 TB_MAX_SPRITE_SIZE = 8192
 
 def maybe_upload_file(local_path):
-    '''Upload a file to remote cloud storage.'''
+    '''Upload a file to remote cloud storage
+    if the path starts with gs:// or s3://
+    '''
     if local_path.startswith(('s3://', 'gs://')):
         prefix = local_path.split(':')[0]
         remote_bucket_path = local_path[len("s3://"):]  # same length

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -867,6 +867,10 @@ class SummaryWriter(object):
             writer.add_embedding(torch.randn(100, 5), label_img=label_img)
             writer.add_embedding(torch.randn(100, 5), metadata=meta)
         """
+
+        # programmer's note: This function has nothing to do with event files.
+        # The hard-coded projector_config.pbtxt is the only source for TensorBoard's
+        # current implementation. (as of Dec. 2019)
         from .x2num import make_np
         mat = make_np(mat)
         if global_step is None:

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,5 +1,6 @@
 import unittest
 import torch
+import boto3
 from tensorboardX import SummaryWriter
 from moto import mock_s3
 
@@ -66,7 +67,9 @@ class EmbeddingTest(unittest.TestCase):
                             global_step=2)
     @mock_s3
     def test_embedding_s3_mock(self):
-        w = SummaryWriter()
+        client = boto3.client('s3', region_name='us-east-1')
+        client.create_bucket(Bucket='this')
+        w = SummaryWriter("s3://this/is/apen")
         all_features = torch.Tensor([[1, 2, 3], [5, 4, 1], [3, 7, 7]])
         all_labels = torch.Tensor([33, 44, 55])
         all_images = torch.zeros(3, 3, 5, 5)

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,6 +1,8 @@
 import unittest
 import torch
 from tensorboardX import SummaryWriter
+from moto import mock_s3
+
 
 
 class EmbeddingTest(unittest.TestCase):
@@ -22,7 +24,6 @@ class EmbeddingTest(unittest.TestCase):
                         label_img=all_images,
                         metadata_header=['digit', 'dataset'],
                         global_step=2)
-        # assert...
 
     def test_embedding_64(self):
         w = SummaryWriter()
@@ -63,3 +64,22 @@ class EmbeddingTest(unittest.TestCase):
             w.add_embedding(all_features,
                             label_img=all_images,
                             global_step=2)
+    @mock_s3
+    def test_embedding_s3_mock(self):
+        w = SummaryWriter()
+        all_features = torch.Tensor([[1, 2, 3], [5, 4, 1], [3, 7, 7]])
+        all_labels = torch.Tensor([33, 44, 55])
+        all_images = torch.zeros(3, 3, 5, 5)
+
+        w.add_embedding(all_features,
+                        metadata=all_labels,
+                        label_img=all_images,
+                        global_step=2)
+
+        dataset_label = ['test'] * 2 + ['train'] * 2
+        all_labels = list(zip(all_labels, dataset_label))
+        w.add_embedding(all_features,
+                        metadata=all_labels,
+                        label_img=all_images,
+                        metadata_header=['digit', 'dataset'],
+                        global_step=2)


### PR DESCRIPTION
This follows the idea of PR 426 and generalized the code so that google cloud storage is supported as well. Since there is code confliction between 426 and master, I opened a new PR instead.

usage: 
`writer = SummaryWriter("gs://your-bucket/embedding-test")`

closes #426 
closes #358 
