### PR TITLE
Handle S3 connection failure

### DIFF
--- a/tensorboardX/event_file_writer.py
+++ b/tensorboardX/event_file_writer.py
@@ -217,7 +217,10 @@ class _EventLoggerThread(threading.Thread):
                     # Small optimization - if there are no pending data,
                     # there's no need to flush, since each flush can be
                     # expensive (e.g. uploading a new file to a server).
-                    self._record_writer.flush()
+                    try:
+                        self._record_writer.flush()
+                    except:
+                        continue
                     self._has_pending_data = False
                 # Do it again in flush_secs.
                 self._next_flush_time = now + self._flush_secs


### PR DESCRIPTION
.flush() in `_EventLoggerThread` create a new connection each time, if there is fluctuation in connection `boto3.client('s3', endpoint_url)` throws an error and since it is not handled the thread will hang and since the queue is full the training will also hang. The try block added will prevent the thread from getting stuck, instead it waits for the connection to appear again. Since it's a `while` loop the training wont resume till the connection is established again. Connection variable will make sure the print happens only once.