### PR TITLE
summary: Fix hparams name display for Callables

### DIFF
--- a/tensorboardX/summary.py
+++ b/tensorboardX/summary.py
@@ -106,6 +106,11 @@ def hparams(hparam_dict=None, metric_dict=None):
             hps.append(HParamInfo(name=k, type=DataType.DATA_TYPE_FLOAT64))
             continue
 
+        if callable(v):
+            ssi.hparams[k].string_value = getattr(v, '__name__', str(v))
+            hps.append(HParamInfo(name=k, type=DataType.DATA_TYPE_STRING))
+            continue
+
         hps.append(HParamInfo(name=k, type=DataType.DATA_TYPE_UNSET))
 
     content = HParamsPluginData(session_start_info=ssi, version=PLUGIN_DATA_VERSION)


### PR DESCRIPTION
fix #579 

This PR fixes the issue by taking the `__name__` field of the callable if it exists, falling back on `str()` when it does not. Tested it on my projects, looks nice!

After fix:
![image](https://user-images.githubusercontent.com/5993887/80744980-73b56d80-8b17-11ea-9697-05082bcb13fb.png)

The "before" screenshot is available in #579 