### PR TITLE
Proposed fix for #567

### DIFF
--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -411,7 +411,10 @@ class SummaryWriter(object):
 
         """
         if self._check_caffe2_blob(scalar_value):
-            scalar_value = workspace.FetchBlob(scalar_value)
+            if 'workspace' in globals():
+                scalar_value = workspace.FetchBlob(scalar_value)
+            else:
+                raise TypeError("Input value: \"{}\" is not a scalar".format(scalar_value))
         self._get_file_writer().add_summary(
             scalar(tag, scalar_value, display_name, summary_description), global_step, walltime)
 


### PR DESCRIPTION
This change should throw a `TypeError` when bad data is passed in to `add_scalar` rather than a `NameError`, which occurs due to the absence of the caffe2 workspace. While there are other approaches, this change would probably help users debug what they have done incorrectly. I welcome feedback if there's a better way to handle this or a test to make.

This change fixes #567 though it doesn't address all the questions therein.