### PR TITLE
tensorboardX requires six but it is not listed among the requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ with open('tensorboardX/__init__.py', 'a') as f:
     f.write('\n__version__ = "{}"\n'.format(version_git))
 
 requirements = [
+    'six',
     'numpy',
     'protobuf >= 3.8.0',
 ]


### PR DESCRIPTION
Check this: https://github.com/lanpa/tensorboardX/search?q=six -- I'm adding it to `setup.py` as a requirement.