### PR TITLE
Try to fix: cannot schedule new futures after interpreter shutdown

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]

--- a/tensorboardX/record_writer.py
+++ b/tensorboardX/record_writer.py
@@ -71,7 +71,8 @@ class S3RecordWriter(object):
         self.buffer = io.BytesIO()
 
     def __del__(self):
-        self.close()
+        if not self.closed:
+            self.close()
 
     def bucket_and_path(self):
         path = self.path
@@ -94,6 +95,7 @@ class S3RecordWriter(object):
 
     def close(self):
         self.flush()
+        self.closed = True
 
 
 class S3RecordWriterFactory(object):

--- a/tensorboardX/record_writer.py
+++ b/tensorboardX/record_writer.py
@@ -69,6 +69,7 @@ class S3RecordWriter(object):
             raise ImportError("boto3 must be installed for S3 support.")
         self.path = path
         self.buffer = io.BytesIO()
+        self.closed = False
 
     def __del__(self):
         if not self.closed:

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -86,3 +86,4 @@ class EmbeddingTest(unittest.TestCase):
                         label_img=all_images,
                         metadata_header=['digit', 'dataset'],
                         global_step=2)
+        w.close()


### PR DESCRIPTION
Test1: Can Github workflow run ubuntu 22.04 daily build?