### PR TITLE
Comet integration improvements

### DIFF
--- a/tensorboardX/comet_utils.py
+++ b/tensorboardX/comet_utils.py
@@ -161,9 +161,9 @@ class CometLogger:
         """Log Raw Histogram Data to Comet as an Asset.
 
         Args:
-            tag (str): Name given to the logged asset
-            summary (proto.summary_pb2.Summary): A Summary protocol buffer containing histogram data
-            step (int, optional): The Global Step for this experiment run. Defaults to None.
+            tag: Name given to the logged asset
+            summary: TensorboardX Summary protocol buffer with histogram data
+            step: The Global Step for this experiment run. Defaults to None.
         """
 
         histogram_proto = summary.value[0].histo

--- a/tensorboardX/comet_utils.py
+++ b/tensorboardX/comet_utils.py
@@ -324,7 +324,7 @@ class CometLogger:
 
         Args:
         tag: An identifier for the PR curve
-        summary: TensorboardX Summary Proto.
+        summary: TensorboardX Summary protocol buffer.
         step: step value to record
         """
         tensor_proto = summary.value[0].tensor
@@ -356,7 +356,7 @@ class CometLogger:
 
         Args:
         tag: An identifier for the PR curve
-        summary: TensorboardX Summary Proto.
+        summary: TensorboardX Summary protocol buffer.
         step: step value to record
         """
         thresholds = [1.0 / num_thresholds * i for i in range(num_thresholds)]

--- a/tensorboardX/comet_utils.py
+++ b/tensorboardX/comet_utils.py
@@ -2,6 +2,7 @@ import logging
 import json
 import functools
 from io import BytesIO
+from google.protobuf.json_format import MessageToJson
 import numpy as np
 from .summary import _clean_tag
 try:
@@ -329,9 +330,9 @@ class CometLogger:
         tensor_proto = summary.value[0].tensor
         shape = [d.size for d in tensor_proto.tensor_shape.dim]
 
-        values = numpy.fromiter(tensor_proto.float_val, dtype=numpy.float32).reshape(shape)
+        values = np.fromiter(tensor_proto.float_val, dtype=np.float32).reshape(shape)
         thresholds = [1.0 / num_thresholds * i for i in range(num_thresholds)]
-        tp, fp, tn, fn, precision, recall = map(lambda x: x.flatten().tolist(), numpy.vsplit(values, values.shape[0]))
+        tp, fp, tn, fn, precision, recall = map(lambda x: x.flatten().tolist(), np.vsplit(values, values.shape[0]))
 
         pr_data = {
             'TP': tp,

--- a/tensorboardX/comet_utils.py
+++ b/tensorboardX/comet_utils.py
@@ -360,8 +360,13 @@ class CometLogger:
         step: step value to record
         """
         thresholds = [1.0 / num_thresholds * i for i in range(num_thresholds)]
-        tp, fp, tn, fn, precision, recall = map(lambda x: x.flatten().tolist(
-        ), [true_positive_counts, false_positive_counts, true_negative_counts, false_negative_counts, precision, recall])
+        tp, fp, tn, fn, precision, recall = map(lambda x: x.flatten().tolist(), [
+            true_positive_counts,
+            false_positive_counts,
+            true_negative_counts,
+            false_negative_counts,
+            precision,
+            recall])
 
         pr_data = {
             'TP': tp,

--- a/tensorboardX/comet_utils.py
+++ b/tensorboardX/comet_utils.py
@@ -156,6 +156,22 @@ class CometLogger:
                                           **kwargs)
 
     @_requiresComet
+    def log_histogram_raw(self, tag, summary, step=None):
+        """Log Raw Histogram Data to Comet as an Asset.
+
+        Args:
+            tag (str): Name given to the logged asset
+            summary (proto.summary_pb2.Summary): A Summary protocol buffer containing histogram data
+            step (int, optional): The Global Step for this experiment run. Defaults to None.
+        """
+
+        histogram_proto = summary.value[0].histo
+        histogram_raw_data = MessageToJson(histogram_proto)
+        histogram_raw_data['name'] = tag
+
+        self.log_asset_data(data=histogram_raw_data, name=tag, step=step)
+
+    @_requiresComet
     def log_curve(self, name, x, y, overwrite=False, step=None):
         """Log timeseries data.
 

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -615,25 +615,19 @@ class SummaryWriter(object):
         """
         if len(bucket_limits) != len(bucket_counts):
             raise ValueError('len(bucket_limits) != len(bucket_counts), see the document.')
+        summary = histogram_raw(tag,
+                                min,
+                                max,
+                                num,
+                                sum,
+                                sum_squares,
+                                bucket_limits,
+                                bucket_counts)
         self._get_file_writer().add_summary(
-            histogram_raw(tag,
-                          min,
-                          max,
-                          num,
-                          sum,
-                          sum_squares,
-                          bucket_limits,
-                          bucket_counts),
+            summary,
             global_step,
             walltime)
-        self._get_comet_logger().log_raw_figure(tag, 'histogram_raw', global_step,
-                                                min=min,
-                                                max=max,
-                                                num=num,
-                                                sum=sum,
-                                                sum_squares=sum_squares,
-                                                bucket_limits=bucket_limits,
-                                                bucket_counts=bucket_counts)
+        self._get_comet_logger().log_histogram_raw(tag, summary, step=global_step)
 
     def add_image(
             self,

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -1136,10 +1136,13 @@ class SummaryWriter(object):
         """
         from .x2num import make_np
         labels, predictions = make_np(labels), make_np(predictions)
+
+        summary = pr_curve(tag, labels, predictions, num_thresholds, weights)
         self._get_file_writer().add_summary(
-            pr_curve(tag, labels, predictions, num_thresholds, weights),
+            summary,
             global_step, walltime)
-        self._get_comet_logger().log_curve(tag, labels, predictions, step=global_step)
+
+        self._get_comet_logger().log_pr_data(tag, summary, num_thresholds, step=global_step)
 
     def add_pr_curve_raw(
             self,
@@ -1176,16 +1179,15 @@ class SummaryWriter(object):
                          weights),
             global_step,
             walltime)
-        self._get_comet_logger().log_raw_figure(tag, 'pr_curve_raw', global_step,
-                                                true_positive_counts=true_positive_counts,
-                                                false_positive_counts=false_positive_counts,
-                                                true_negative_counts=true_negative_counts,
-                                                false_negative_counts=false_negative_counts,
-                                                precision=precision,
-                                                recall=recall,
-                                                num_thresholds=num_thresholds,
-                                                weights=weights,
-                                                walltime=walltime)
+        self._get_comet_logger().log_pr_raw_data(tag, step=global_step,
+                                                 true_positive_counts=true_positive_counts,
+                                                 false_positive_counts=false_positive_counts,
+                                                 true_negative_counts=true_negative_counts,
+                                                 false_negative_counts=false_negative_counts,
+                                                 precision=precision,
+                                                 recall=recall,
+                                                 num_thresholds=num_thresholds,
+                                                 weights=weights)
 
     def add_custom_scalars_multilinechart(
             self,


### PR DESCRIPTION
This PR:

1. Fixes PR Curve logging issue with Comet  and the `add_pr_curve` method. Comet will now log the computed PR curve as opposed to the Predictions and Labels
2. Fixes the logging issue for raw Histogram Data to Comet from the `add_histogram_raw` method. Comet will now log the histogram data, instead of the generated Proto file. 

  