### PR TITLE
Allow for larger version of protobuf

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ with open('tensorboardX/__init__.py', 'a') as f:
 
 requirements = [
     'numpy',
-    'protobuf>=3.8.0,<=3.20.3',
+    'protobuf>=3.8.0,<4',
 ]
 
 


### PR DESCRIPTION
onnx (1.13.0) depends on protobuf (>=3.20.2,<4)
tensorboardx (2.5.1) depends on protobuf (>=3.8.0,<=3.20.1) ==> tensorboardx not compatible with tensorboardx. Can we just allow for a larger version of protobuf please?

(Related to https://github.com/lanpa/tensorboardX/issues/678)