### PR TITLE
change unittest multiprocess start method to fork

### DIFF
--- a/tests/test_multiprocess_write.py
+++ b/tests/test_multiprocess_write.py
@@ -9,6 +9,7 @@ import pytest
 import unittest
 import time
 
+mp.set_start_method('fork')
 
 class GlobalWriterTest(unittest.TestCase):
     def test_flush(self):
@@ -88,4 +89,5 @@ class GlobalWriterTest(unittest.TestCase):
         collected_values = sorted(collected_values)
         for i in range(TEST_LEN):
             for j in range(N_PROC):
-                assert collected_values[i*N_PROC+j] == i 
+                assert collected_values[i*N_PROC+j] == i
+


### PR DESCRIPTION
```
tests/test_multiprocess_write.py:72:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../miniconda3/envs/tbx311/lib/python3.11/multiprocessing/process.py:121: in start
    self._popen = self._Popen(self)
../../miniconda3/envs/tbx311/lib/python3.11/multiprocessing/context.py:224: in _Popen
    return _default_context.get_context().Process._Popen(process_obj)
../../miniconda3/envs/tbx311/lib/python3.11/multiprocessing/context.py:288: in _Popen
    return Popen(process_obj)
../../miniconda3/envs/tbx311/lib/python3.11/multiprocessing/popen_spawn_posix.py:32: in __init__
    super().__init__(process_obj)
../../miniconda3/envs/tbx311/lib/python3.11/multiprocessing/popen_fork.py:19: in __init__
    self._launch(process_obj)
../../miniconda3/envs/tbx311/lib/python3.11/multiprocessing/popen_spawn_posix.py:47: in _launch
    reduction.dump(process_obj, fp)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

obj = <Process name='Process-21' parent=84214 initial>, file = <_io.BytesIO object at 0x13b315170>, protocol = None

    def dump(obj, file, protocol=None):
        '''Replacement for pickle.dump() using ForkingPickler.'''
>       ForkingPickler(file, protocol).dump(obj)
E       AttributeError: Can't pickle local object 'GlobalWriterTest.test_writer.<locals>.train3'
```