### PR TITLE
Use matplotlib's agg backend in test_figure.py.

### DIFF
--- a/tests/test_figure.py
+++ b/tests/test_figure.py
@@ -3,6 +3,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import matplotlib
+matplotlib.use('agg')
+
 import matplotlib.pyplot as plt
 import unittest
 


### PR DESCRIPTION
By default, matplotlib will use an interactive backend when it detects that one is available. This is both unnecessary and, in some cases, can break builds.

One example of a build breaking is on macOS Ventura when these tests are run using a non-root user (such as a user used for builds) that is not the logged-in user. The interactive macOS backend crashes with an error in _xpc_api_misuse when creating an NSWindow, likely due to some tighter security requirements.