### PR TITLE
Drop minimum Protobuf version to 4.21.6

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -56,7 +56,7 @@ jobs:
         python-version: 3.9
     - name: Run examples
       run: |
-        pip install six tensorboard pytest matplotlib torchvision protobuf==4.22.3 moviepy==1.0.3 imageio==2.27
+        pip install six tensorboard pytest matplotlib torchvision protobuf==4.21.6 moviepy==1.0.3 imageio==2.27
         python examples/demo.py
         python examples/demo_graph.py
         python examples/demo_embedding.py

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ with open('HISTORY.rst') as history_file:
 requirements = [
     'numpy',
     'packaging',
-    'protobuf>=4.22.3',
+    'protobuf>=4.21.6',
 ]
 
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ flake8
 pytest
 torch
 torchvision
-protobuf==4.22.3
+protobuf==4.21.6
 numpy
 tensorboard
 boto3


### PR DESCRIPTION
Can we drop the minimum Protobuf version from 4.22.3 to 4.21.6, please?

All tests seem to pass. But there might be nuances about changes in 4.22 that I'm not aware of.

The reason I'm asking for this is because I have a dependency on cuDF, which requires `protobuf<4.22,>=4.21.6`. 

Thanks very much!
