### PR TITLE
Fix: make writer fw_tag windows compatible

### DIFF
--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -494,7 +494,7 @@ class SummaryWriter(object):
         walltime = time.time() if walltime is None else walltime
         fw_logdir = self._get_file_writer().get_logdir()
         for tag, scalar_value in tag_scalar_dict.items():
-            fw_tag = fw_logdir + "/" + main_tag + "/" + tag
+            fw_tag = os.path.join(str(fw_logdir), main_tag, tag)
             if fw_tag in self.all_writers.keys():
                 fw = self.all_writers[fw_tag]
             else:


### PR DESCRIPTION
In add_scalars, fw_tag is actually a path, which should be handled by `os.path.join(str(fw_logdir), main_tag, tag)` rather than `fw_logdir+'/'+ main_tag+'/'+ tag` which only works on unix systems.

This fix bugs which might occur on windows platform.