### PR TITLE
made optional data format args actually optional

### DIFF
--- a/tensorboardX/utils.py
+++ b/tensorboardX/utils.py
@@ -130,11 +130,12 @@ def convert_to_HWC(tensor, input_format):  # tensor: numpy array
         tensor = np.stack([tensor, tensor, tensor], 2)
         return tensor
 
+
 def infer_image_format(tensor):
     """
     Attempt to infer the image format from the data.
 
-    This function can really only detect the color channel, and assumes that 
+    This function can really only detect the color channel, and assumes that
     all other channels are in the order NTHW (if present).
     """
     import numpy as np
@@ -143,14 +144,14 @@ def infer_image_format(tensor):
         return "HW"
     elif tensor.ndim == 3:
         # Hopefully we can determine that exactly one of these is the channel
-        C_first = tensor.shape[0] in [1,3,4] 
-        C_last = tensor.shape[2] in [1,3,4] 
+        C_first = tensor.shape[0] in [1, 3, 4]
+        C_last = tensor.shape[2] in [1, 3, 4]
         assert C_first != C_last, "Could not uniquely determine the color channel index: \
             you must spedicify the format yourself"
         return "CHW" if C_first else "HWC"
     elif tensor.ndim == 4:
-        return 'N'+ infer_image_format(tensor[0])
+        return 'N' + infer_image_format(tensor[0])
     elif tensor.ndim == 5:
-        return 'NT'+ infer_image_format(tensor[0,0])
+        return 'NT' + infer_image_format(tensor[0, 0])
     else:
         raise NotImplementedError("Unable to infer image format for arrays with <2 or >5 dimensions.")

--- a/tensorboardX/utils.py
+++ b/tensorboardX/utils.py
@@ -129,3 +129,28 @@ def convert_to_HWC(tensor, input_format):  # tensor: numpy array
         tensor = tensor.transpose(index)
         tensor = np.stack([tensor, tensor, tensor], 2)
         return tensor
+
+def infer_image_format(tensor):
+    """
+    Attempt to infer the image format from the data.
+
+    This function can really only detect the color channel, and assumes that 
+    all other channels are in the order NTHW (if present).
+    """
+    import numpy as np
+    tensor: np.ndarray = tensor
+    if tensor.ndim == 2:
+        return "HW"
+    elif tensor.ndim == 3:
+        # Hopefully we can determine that exactly one of these is the channel
+        C_first = tensor.shape[0] in [1,3,4] 
+        C_last = tensor.shape[2] in [1,3,4] 
+        assert C_first != C_last, "Could not uniquely determine the color channel index: \
+            you must spedicify the format yourself"
+        return "CHW" if C_first else "HWC"
+    elif tensor.ndim == 4:
+        return 'N'+ infer_image_format(tensor[0])
+    elif tensor.ndim == 5:
+        return 'NT'+ infer_image_format(tensor[0,0])
+    else:
+        raise NotImplementedError("Unable to infer image format for arrays with <2 or >5 dimensions.")

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -634,7 +634,7 @@ class SummaryWriter(object):
             img_tensor: numpy_compatible,
             global_step: Optional[int] = None,
             walltime: Optional[float] = None,
-            dataformats: Optional[str] = 'CHW'):
+            dataformats: Optional[str] = None):
         """Add image data to summary.
 
         Note that this requires the ``pillow`` package.
@@ -694,7 +694,7 @@ class SummaryWriter(object):
             img_tensor: numpy_compatible,
             global_step: Optional[int] = None,
             walltime: Optional[float] = None,
-            dataformats: Optional[str] = 'NCHW'):
+            dataformats: Optional[str] = None):
         """Add batched (4D) image data to summary.
         Besides passing 4D (NCHW) tensor, you can also pass a list of tensors of the same size.
         In this case, the ``dataformats`` should be `CHW` or `HWC`.
@@ -734,10 +734,6 @@ class SummaryWriter(object):
         if self._check_caffe2_blob(img_tensor):
             img_tensor = workspace.FetchBlob(img_tensor)
         if isinstance(img_tensor, list):  # a list of tensors in CHW or HWC
-            if dataformats.upper() != 'CHW' and dataformats.upper() != 'HWC':
-                print('A list of image is passed, but the dataformat is neither CHW nor HWC.')
-                print('Nothing is written.')
-                return
             import torch
             try:
                 img_tensor = torch.stack(img_tensor, 0)
@@ -745,7 +741,8 @@ class SummaryWriter(object):
                 import numpy as np
                 img_tensor = np.stack(img_tensor, 0)
 
-            dataformats = 'N' + dataformats
+            if dataformats is not None and len(dataformats) == 3:
+                dataformats = 'N' + dataformats
 
         summary = image(tag, img_tensor, dataformats=dataformats)
         encoded_image_string = summary.value[0].image.encoded_image_string
@@ -760,7 +757,7 @@ class SummaryWriter(object):
             box_tensor: numpy_compatible,
             global_step: Optional[int] = None,
             walltime: Optional[float] = None,
-            dataformats: Optional[str] = 'CHW',
+            dataformats: Optional[str] = None,
             labels: Optional[List[str]] = None,
             **kwargs):
         """Add image and draw bounding boxes on the image.
@@ -827,7 +824,7 @@ class SummaryWriter(object):
             global_step: Optional[int] = None,
             fps: Optional[Union[int, float]] = 4,
             walltime: Optional[float] = None,
-            dataformats: Optional[str] = 'NTCHW'):
+            dataformats: Optional[str] = None):
         """Add video data to summary.
 
         Note that this requires the ``moviepy`` package.

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,7 +7,7 @@ numpy
 tensorboard
 boto3
 matplotlib
-moto
+moto<5
 soundfile
 visdom
 onnx


### PR DESCRIPTION
Functions like `add_image` and `add_video` indicate that the `dataformats` arg is optional. However, there was no code to handle the `None` case. This commit adds a function that enables automatic determination of which channel is the color channel and invokes it whenever `dataformats` is `None`. It makes assumptions about the ordering of the other channels, but it should cover 80% of use cases. 