### PR TITLE
Add `use_metadata` context manager (fixes #745).

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         curl -Os https://cli.codecov.io/latest/linux/codecov
         chmod +x codecov
-        ./codecov --verbose upload-process --fail-on-error -t ${{ secrets.CODECOV_TOKEN }} -n 'service'-${{ github.run_id }} -F service -f coverage.xml
+        ./codecov --verbose upload-process --fail-on-error -n 'service'-${{ github.run_id }} -F service -f coverage.xml
 
   test:
     needs: build

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ runs/*
 mnist
 tensorboardX/_version.py
 s3:
+.coverage
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ runs/*
 *.pyc
 mnist
 tensorboardX/_version.py
+s3:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ runs/*
 mnist
 tensorboardX/_version.py
 s3:
+.vscode

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -26,43 +26,44 @@ recall = [1.0, 0.8533334, 0.28, 0.0666667, 0.0]
 
 
 for n_iter in range(100):
-    s1 = torch.rand(1)  # value to keep
-    s2 = torch.rand(1)
-    # data grouping by `slash`
-    writer.add_scalar('data/scalar_systemtime', s1[0], n_iter, summary_description="# markdown is supported!")
-    # data grouping by `slash`
-    writer.add_scalar('data/scalar_customtime', s1[0], n_iter, walltime=n_iter, display_name="dudubird")
-    writer.add_scalars('data/scalar_group', {"xsinx": n_iter * np.sin(n_iter),
-                                             "xcosx": n_iter * np.cos(n_iter),
-                                             "arctanx": np.arctan(n_iter)}, n_iter)
-    x = torch.rand(32, 3, 64, 64)  # output from network
-    if n_iter % 10 == 0:
-        x = vutils.make_grid(x, normalize=True, scale_each=True)
-        writer.add_image('Image', x, n_iter)  # Tensor
-        writer.add_image_with_boxes('imagebox_label', torch.ones(3, 240, 240) * 0.5,
-             torch.Tensor([[10, 10, 100, 100], [101, 101, 200, 200]]),
-             n_iter, 
-             labels=['abcde' + str(n_iter), 'fgh' + str(n_iter)])
-        if not skip_audio:
-            x = torch.zeros(sample_rate * 2)
-            for i in range(x.size(0)):
-                # sound amplitude should in [-1, 1]
-                x[i] = np.cos(freqs[n_iter // 10] * np.pi *
-                            float(i) / float(sample_rate))
-            writer.add_audio('myAudio', x, n_iter)
-        writer.add_text('Text', 'text logged at step:' + str(n_iter), n_iter)
-        writer.add_text('markdown Text', '''a|b\n-|-\nc|d''', n_iter)
-        for name, param in resnet18.named_parameters():
-            if 'bn' not in name:
-                writer.add_histogram(name, param, n_iter)
-        writer.add_pr_curve('xoxo', np.random.randint(2, size=100), np.random.rand(
-            100), n_iter)  # needs tensorboard 0.4RC or later
-        writer.add_pr_curve_raw('prcurve with raw data', true_positive_counts,
-                                false_positive_counts,
-                                true_negative_counts,
-                                false_negative_counts,
-                                precision,
-                                recall, n_iter)
+    with writer.use_metadata(global_step=n_iter):
+        s1 = torch.rand(1)  # value to keep
+        s2 = torch.rand(1)
+        # data grouping by `slash`
+        writer.add_scalar('data/scalar_systemtime', s1[0], summary_description="# markdown is supported!")
+        # data grouping by `slash`
+        writer.add_scalar('data/scalar_customtime', s1[0], walltime=n_iter, display_name="dudubird")
+        writer.add_scalars('data/scalar_group', {"xsinx": n_iter * np.sin(n_iter),
+                                                 "xcosx": n_iter * np.cos(n_iter),
+                                                 "arctanx": np.arctan(n_iter)})
+        x = torch.rand(32, 3, 64, 64)  # output from network
+        if n_iter % 10 == 0:
+            x = vutils.make_grid(x, normalize=True, scale_each=True)
+            writer.add_image('Image', x)  # Tensor
+            writer.add_image_with_boxes(
+                'imagebox_label', torch.ones(3, 240, 240) * 0.5,
+                torch.Tensor([[10, 10, 100, 100], [101, 101, 200, 200]]),
+                labels=['abcde' + str(n_iter), 'fgh' + str(n_iter)])
+            if not skip_audio:
+                x = torch.zeros(sample_rate * 2)
+                for i in range(x.size(0)):
+                    # sound amplitude should in [-1, 1]
+                    x[i] = np.cos(freqs[n_iter // 10] * np.pi *
+                                  float(i) / float(sample_rate))
+                writer.add_audio('myAudio', x)
+            writer.add_text('Text', 'text logged at step:' + str(n_iter))
+            writer.add_text('markdown Text', '''a|b\n-|-\nc|d''')
+            for name, param in resnet18.named_parameters():
+                if 'bn' not in name:
+                    writer.add_histogram(name, param)
+            writer.add_pr_curve('xoxo', np.random.randint(2, size=100), np.random.rand(
+                100))  # needs tensorboard 0.4RC or later
+            writer.add_pr_curve_raw('prcurve with raw data', true_positive_counts,
+                                    false_positive_counts,
+                                    true_negative_counts,
+                                    false_negative_counts,
+                                    precision,
+                                    recall)
 # export scalar data to JSON for external processing
 writer.export_scalars_to_json("./all_scalars.json")
 

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -137,11 +137,13 @@ class FileWriter:
           walltime: float. Optional walltime to override the default (current)
             walltime (from time.time())
         """
-        event.wall_time = (
+        walltime = (
             self._default_metadata.get("walltime", time.time())
             if walltime is None
             else walltime
         )
+        if walltime is not None:
+            event.wall_time = walltime
         step = self._default_metadata.get("global_step") if step is None else step
         if step is not None:
             # Make sure step is converted from numpy or other formats

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -3,6 +3,7 @@ consumed by TensorBoard for visualization."""
 
 
 import atexit
+import contextlib
 import json
 import logging
 import os
@@ -77,6 +78,10 @@ class DummyFileWriter:
     def reopen(self):
         return
 
+    @contextlib.contextmanager
+    def use_metadata(self, *, global_step=None, walltime=None):
+        yield self
+
 
 class FileWriter:
     """Writes protocol buffers to event files to be consumed by TensorBoard.
@@ -117,6 +122,7 @@ class FileWriter:
             self.event_writer.close()
 
         atexit.register(cleanup)
+        self._default_metadata = {}
 
     def get_logdir(self):
         """Returns the directory where event file will be written."""
@@ -131,7 +137,12 @@ class FileWriter:
           walltime: float. Optional walltime to override the default (current)
             walltime (from time.time())
         """
-        event.wall_time = time.time() if walltime is None else walltime
+        event.wall_time = (
+            self._default_metadata.get("walltime", time.time())
+            if walltime is None
+            else walltime
+        )
+        step = self._default_metadata.get("global_step") if step is None else step
         if step is not None:
             # Make sure step is converted from numpy or other formats
             # since protobuf might not convert depending on version
@@ -213,6 +224,28 @@ class FileWriter:
         Does nothing if the EventFileWriter was not closed.
         """
         self.event_writer.reopen()
+
+    @contextlib.contextmanager
+    def use_metadata(self, *, global_step=None, walltime=None):
+        """Context manager to temporarily set default metadata for all enclosed :meth:`add_event`
+        calls.
+
+        Args:
+            global_step: Global step value to record
+            walltime: Walltime to record (defaults to time.time())
+
+        Examples::
+
+            with writer.use_metadata(global_step=10):
+                writer.add_event(event)
+        """
+        assert not self._default_metadata, "Default metadata is already set."
+        assert (
+            global_step is not None or walltime is not None
+        ), "At least one of `global_step` or `walltime` must be provided."
+        self._default_metadata = {"global_step": global_step, "walltime": walltime}
+        yield self
+        self._default_metadata = {}
 
 
 class SummaryWriter:
@@ -319,6 +352,7 @@ class SummaryWriter:
         self.default_bins = neg_buckets[::-1] + [0] + buckets
 
         self.scalar_dict = {}
+        self._default_metadata = {}
 
     def __append_to_scalar_dict(self, tag, scalar_value, global_step,
                                 timestamp):
@@ -1227,3 +1261,19 @@ class SummaryWriter:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
+
+    @contextlib.contextmanager
+    def use_metadata(self, *, global_step=None, walltime=None):
+        """Context manager to temporarily set default metadata for all enclosed :meth:`add_*` calls.
+
+        Args:
+            global_step: Global step value to record
+            walltime: Walltime to record (defaults to time.time())
+
+        Examples::
+
+            with writer.use_metadata(global_step=10):
+                writer.add_scalar("loss", 3.0)
+        """
+        with self._get_file_writer().use_metadata(global_step=global_step, walltime=walltime):
+            yield self

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -865,7 +865,7 @@ class SummaryWriter:
             self,
             tag: str,
             snd_tensor: numpy_compatible,
-            global_step: Optional[int],
+            global_step: Optional[int] = None,
             sample_rate: Optional[int] = 44100,
             walltime: Optional[float] = None):
         """Add audio data to summary.

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -55,19 +55,6 @@ class WriterTest(unittest.TestCase):
         for _ in range(N_TEST):  # all of the data should be flushed
             r.GetNext()
 
-    def test_flush(self):
-        N_TEST = 5
-        w = SummaryWriter(flush_secs=20)
-        f = w.file_writer.event_writer._ev_writer._file_name
-        for i in range(N_TEST):
-            w.add_scalar('a', i)
-            time.sleep(2)
-        w.flush()
-        r = PyRecordReader_New(f)
-        r.GetNext()  # meta data, so skip
-        for _ in range(N_TEST):  # all of the data should be flushed
-            r.GetNext()
-
     def test_auto_close(self):
         pass
 
@@ -75,7 +62,6 @@ class WriterTest(unittest.TestCase):
         w = SummaryWriter()
         w.close()
         w.add_text("reuse writer", "dont reuse without creating a new writer", 0)
-
 
     def test_writer(self):
         with SummaryWriter() as writer:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -103,13 +103,13 @@ class WriterTest(unittest.TestCase):
             with SummaryWriter() as w:
                 w.add_images('img_list', imgs, dataformats='CHW')
 
-    def test_writer_with_default_metadata(self, write_to_disk):
+    def test_writer_with_default_metadata(self):
         step = 17
         walltime = 13.0
 
         with (
             unittest.mock.patch("tensorboardX.event_file_writer.EventFileWriter.add_event") as fn,
-            SummaryWriter(write_to_disk=write_to_disk) as writer,
+            SummaryWriter() as writer,
         ):
             # Check defaults are used unless explicitly specified.
             with writer.use_metadata(global_step=step, walltime=walltime):


### PR DESCRIPTION
This PR adds a `use_metadata` context manager to specify default values for `global_step` and `walltime`. There are some usage examples in the tests, and I've updated the demo file to illustrate the use of the context manager.

I didn't quite know the right level of the codebase to add the state to. For now, I settled on the `FileWriter` class because all `add_*` seem to go through the `add_event` method of the `FileWriter` so it was easy to inject the defaults there. The `SummaryWriter` class has a convenience context manager method which just wraps the associated `FileWriter`.

I also dropped one duplicate test definition `test_flush` while adding the tests.

This PR currently does not support the comet logger because I wasn't quite sure about the right implementation. Comments welcome.