### PR TITLE
Fix pillow version on 11.0.0 for test env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
     "onnx>=1.17.0",
     "imageio==2.27",
     "ruff>=0.8.4",
+    "pillow==11.0.0",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
Didn't check thoroughly, but I guess the difference of png encoding comes here:
https://github.com/python-pillow/Pillow/pull/8836
Which is included in version 11.1, and it failed the encoded string comparison.